### PR TITLE
MySQL exception in inventory module

### DIFF
--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -10,10 +10,10 @@ class Inventory < ActiveRecord::Base
   belongs_to :inventory_status
   has_many :attachments, :dependent => :destroy
 
-  scope :unique_name, -> { group(:name) }
-  scope :unique_place, -> { group(:place) }
-  scope :unique_category, -> { group(:category) }
-  scope :unique_seller, -> { group(:seller) }
+  scope :unique_name, -> { group(:id, :name) }
+  scope :unique_place, -> { group(:id, :place) }
+  scope :unique_category, -> { group(:id, :category) }
+  scope :unique_seller, -> { group(:id, :seller) }
 
   validates :purchase_date, format: { with: /\d{4}\-\d{2}\-\d{2}/,
     message: "has to be of format YYYY-MM-DD" }, :allow_blank => true


### PR DESCRIPTION
this is caused by the mysql update to >= 5.7.5 as the mentioned sql mode ONLY_FULL_GROUP_BY was introduced in 5.7.5 https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by

"SQL92 and earlier does not permit queries for which the select list, HAVING condition, or ORDER BY list refer to nonaggregated columns that are neither named in the GROUP BY clause nor are functionally dependent on (uniquely determined by) GROUP BY columns."
https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html

Grouping by "id" and "place" fixes this issue. I fixed it accordingly for the other autocompleted fields of inventory items.