### PR TITLE
fix aliases non updateable via api

### DIFF
--- a/app/forms/editable_machine_form.rb
+++ b/app/forms/editable_machine_form.rb
@@ -57,6 +57,7 @@ class EditableMachineForm
     nics = recursive_symbolize_keys(nics) || Array.new
 
     aliases = params.delete(:aliases) || Array.new
+    aliases = recursive_symbolize_keys(aliases)
 
     nics_changed = false
 


### PR DESCRIPTION
the extracted hash was using strings instead of symbols as key. it now uses recursive_symbolize_keys like the nics hash.