### PR TITLE
fix broken 1.6.6

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,7 @@
+1.6.7
+=====
+- [bugfix] supersede broken 1.6.6 release with 1.6.7
+
 1.6.6
 =====
 - [bugfix] show aliases and nics when querying machines via v2 API.


### PR DESCRIPTION
the patch to show aliases in api v2 wasn't applied for 1.6.6. include this patch and update changelog.