### PR TITLE
5050 filter internal fields from api input

### DIFF
--- a/app/api/v3/cloud_providers.rb
+++ b/app/api/v3/cloud_providers.rb
@@ -24,12 +24,18 @@ module V3
         end
 
         desc 'Update a single cloud provider', success: CloudProvider::Entity
+        params do
+          requires :name, type: String, documentation: { type: "String", desc: "Cloud Provider name" }
+          optional :description, type: String, documentation: { type: "String", desc: "Cloud Provider description" }
+          requires :config, type: String, documentation: { type: "String", desc: "Cloud Provider configuration" }
+          optional :apidocs, type: String, documentation: { type: "String", desc: "Link to API documentation for this Cloud Provider" }
+        end        
         put do
           can_write!
           c = CloudProvider.find_by_inventory_number params[:name]
           error!('Not found', 404) unless c
 
-          p = params.select { |k| CloudProvider.attribute_method?(k) }
+          p = declared(params).to_h
 
           c.update_attributes(p)
 
@@ -68,9 +74,15 @@ module V3
       end
 
       desc 'Create a new cloud provider', success: CloudProvider::Entity
+      params do
+        requires :name, type: String, documentation: { type: "String", desc: "Cloud Provider name" }
+        optional :description, type: String, documentation: { type: "String", desc: "Cloud Provider description" }
+        requires :config, type: String, documentation: { type: "String", desc: "Cloud Provider configuration" }
+        optional :apidocs, type: String, documentation: { type: "String", desc: "Link to API documentation for this Cloud Provider" }
+      end
       post do
         can_write!
-        p = params.select { |k| CloudProvider.attribute_method?(k) }
+        p = declared(params).to_h
         c = CloudProvider.new(p)
         c.owner = @owner
         c.save!

--- a/app/api/v3/inventories.rb
+++ b/app/api/v3/inventories.rb
@@ -48,6 +48,9 @@ module V3
           end
 
           desc 'Create an attachment', success: Attachment::Entity
+          params do
+            requires :data, type: Rack::Multipart::UploadedFile
+          end
           post do
             can_write!
             i = Inventory.find_by_inventory_number params[:number]

--- a/app/api/v3/inventories.rb
+++ b/app/api/v3/inventories.rb
@@ -14,7 +14,7 @@ module V3
         @owner = get_owner
       end
 
-      route_param :number, type: String do
+      route_param :inventory_number, type: String do
         resource :attachments do
           route_param :fingerprint, type: String, requirements: { fingerprint: /[a-f0-9]+/ } do
             desc 'Get an attachment', detail: 'WAT?',
@@ -41,7 +41,7 @@ module V3
                                       success: Attachment::Entity
           get do
             can_read!
-            i = Inventory.find_by_inventory_number params[:number]
+            i = Inventory.find_by_inventory_number params[:inventory_number]
             error!('Not Found', 404) unless i
 
             present i.attachments
@@ -53,7 +53,7 @@ module V3
           end
           post do
             can_write!
-            i = Inventory.find_by_inventory_number params[:number]
+            i = Inventory.find_by_inventory_number params[:inventory_number]
             error!('Not Found', 404) unless i
 
             x = {
@@ -71,16 +71,32 @@ module V3
         desc 'Get a inventory by inventory number', success: Inventory::Entity
         get do
           can_read!
-          i = Inventory.find_by_inventory_number params[:number]
+          i = Inventory.find_by_inventory_number params[:inventory_number]
           error!('Not found', 404) unless i
 
           present i
         end
 
         desc 'Update a single inventory', success: Inventory::Entity
+        params do
+          requires :inventory_number, type: String, documentation: { type: "String", desc: "Inventory Number" }
+          optional :name, type: String, documentation: { type: "String", desc: "Name" }
+          optional :serial, type: String, documentation: { type: "String", desc: "Factory serial number" }
+          optional :part_number, type: String, documentation: { type: "String", desc: "Factory part number" }
+          optional :purchase_date, type: String, documentation: { type: "String", desc: "Purchase date as YYYY-MM-DD" }
+          optional :warranty_end, type: String, documentation: { type: "String", desc: "Warranty end date as YYYY-MM-DD" }
+          optional :seller, type: String, documentation: { type: "String", desc: "Seller" }
+          optional :machine, type: String, documentation: { type: "String", desc: "machines FQDN if this inventoy is a machine" }
+          optional :comment, type: String, documentation: { type: "String", desc: "Comment field" }
+          optional :place, type: String, documentation: { type: "String", desc: "Additional place description" }
+          optional :category, type: String, documentation: { type: "String", desc: "Additional category description" }
+          optional :location_id, type: Integer, documentation: { type: "Integer", desc: "ID of the location" }
+          optional :install_date, type: String, documentation: { type: "String", desc: "Installation date as YYYY-MM-DD" }
+          optional :inventory_status_id, type: Integer, documentation: { type: "Integer", desc: "Inventory status id" }
+        end
         put do
           can_write!
-          i = Inventory.find_by_inventory_number params[:number]
+          i = Inventory.find_by_inventory_number params[:inventory_number]
           error!('Not found', 404) unless i
 
           p = params.select { |k| Inventory.attribute_method?(k) }
@@ -93,7 +109,7 @@ module V3
         desc 'Delete a inventory'
         delete do
           can_write!
-          i = Inventory.find_by_inventory_number params[:number]
+          i = Inventory.find_by_inventory_number params[:inventory_number]
           error!('Not found', 404) unless i
 
           present i.destroy
@@ -131,6 +147,22 @@ module V3
       end
 
       desc 'Create a new inventory', success: Inventory::Entity
+      params do
+        requires :inventory_number, type: String, documentation: { type: "String", desc: "Inventory Number" }
+        optional :name, type: String, documentation: { type: "String", desc: "Name" }
+        optional :serial, type: String, documentation: { type: "String", desc: "Factory serial number" }
+        optional :part_number, type: String, documentation: { type: "String", desc: "Factory part number" }
+        optional :purchase_date, type: String, documentation: { type: "String", desc: "Purchase date as YYYY-MM-DD" }
+        optional :warranty_end, type: String, documentation: { type: "String", desc: "Warranty end date as YYYY-MM-DD" }
+        optional :seller, type: String, documentation: { type: "String", desc: "Seller" }
+        optional :machine, type: String, documentation: { type: "String", desc: "machines FQDN if this inventoy is a machine" }
+        optional :comment, type: String, documentation: { type: "String", desc: "Comment field" }
+        optional :place, type: String, documentation: { type: "String", desc: "Additional place description" }
+        optional :category, type: String, documentation: { type: "String", desc: "Additional category description" }
+        optional :location_id, type: Integer, documentation: { type: "Integer", desc: "ID of the location" }
+        optional :install_date, type: String, documentation: { type: "String", desc: "Installation date as YYYY-MM-DD" }
+        optional :inventory_status_id, type: Integer, documentation: { type: "Integer", desc: "Inventory status id" }
+      end
       post do
         can_write!
         p = params.select { |k| Inventory.attribute_method?(k) }

--- a/app/api/v3/locations.rb
+++ b/app/api/v3/locations.rb
@@ -10,6 +10,7 @@ module V3
         api_enabled!
         authenticate!
         set_papertrail
+        @owner = get_owner
       end
 
       resource :id do
@@ -22,19 +23,50 @@ module V3
             l
           end
 
-          # FIXME
           desc 'Create a new child location', success: Location::Entity
+          params do
+            requires :id, type: Integer
+            requires :name, type: String, documentation: { type: "String", desc: "Name" }
+            optional :description, type: String, documentation: { type: "String", desc: "Description" }
+            requires :level, type: Integer, documentation: { type: "String", desc: "Location level" }
+          end
           post do
+            can_write!
+
+            parent = Location.find_by_id params[:id]
+            error!('Not Found', 404) unless parent
+
+            p = declared(params).to_h
+            child = Location.new(p)
+            child.owner = @owner
+            child.save!
+            parent.add_child(child)
           end
 
-          # FIXME
           desc 'Update a location', success: Location::Entity
+          params do
+            requires :id, type: Integer
+            requires :name, type: String, documentation: { type: "String", desc: "Name" }
+            optional :description, type: String, documentation: { type: "String", desc: "Description" }
+            requires :level, type: Integer, documentation: { type: "String", desc: "Location level" }
+          end
           put do
+            can_write!
+
+            l = Location.find_by_id params[:id]
+            error!('Not Found', 404) unless l
+
+            p = declared(params).to_h
+            l.update_attributes(p)
+            l.save!
           end
 
-          # FIXME
           desc 'Delete a location'
           delete do
+            can_write!
+            l = Location.find_by_id params[:id]
+            error!('Not Found', 404) unless l
+            l.destroy
           end
         end
       end
@@ -49,17 +81,19 @@ module V3
 
         # FIXME
         desc 'Create a new location root', success: Location::Entity
+        params do
+          requires :name, type: String, documentation: { type: "String", desc: "Name" }
+          optional :description, type: String, documentation: { type: "String", desc: "Description" }
+        end
         post do
-        end
+          can_write!
 
-        # FIXME
-        desc 'Update a location root', success: Location::Entity
-        put do
-        end
+          p = declared(params).to_h
+          l = Location.new(p)
+          l.owner = @owner
+          l.save!
 
-        # FIXME
-        desc 'Delete a location root'
-        delete do
+          l
         end
       end
 
@@ -86,8 +120,8 @@ module V3
         end
       end
 
-      desc 'Return a list of location levels, possibly filtered', is_array: true,
-                                                                  success: LocationLevel::Entity
+      desc 'Return a list of locations, possibly filtered', is_array: true,
+                                                                  success: Location::Entity
       get do
         can_read!
 

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -237,7 +237,7 @@ module V3
           optional :backup_last_inc_size, type: String, documentation: { type: "String", desc: "Name" }
           optional :backup_last_diff_size, type: String, documentation: { type: "String", desc: "Name" }
           optional :needs_reboot, type: Integer
-          optional :software, type: JSON, documentation: { type: "JSON", desc: "Known installed doftware packages" }
+          optional :software, type: Array, documentation: { type: "JSON", desc: "Known installed doftware packages" }
           optional :power_feed_a, documentation: { type: "Integer", desc: "Location id of power feed a" }
           optional :power_feed_b, documentation: { type: "Integer", desc: "Location id of power feed b" }
         end
@@ -350,7 +350,7 @@ module V3
         optional :backup_last_inc_size, type: String, documentation: { type: "String", desc: "Name" }
         optional :backup_last_diff_size, type: String, documentation: { type: "String", desc: "Name" }
         optional :needs_reboot, type: Integer
-        optional :software, type: JSON, documentation: { type: "JSON", desc: "Known installed software packages" }
+        optional :software, type: Array, documentation: { type: "JSON", desc: "Known installed software packages" }
         optional :power_feed_a, documentation: { type: "Integer", desc: "Location id of power feed a" }
         optional :power_feed_b, documentation: { type: "Integer", desc: "Location id of power feed b" }
       end

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -203,15 +203,50 @@ module V3
         end
 
         desc 'Update a single machine', success: Machine::Entity
+        params do
+          optional :os, type: String
+          optional :os_release, type: String
+          optional :arch, type: String
+          optional :ram, type: Integer
+          optional :cores, type: Integer
+          optional :vmhost, type: String
+          optional :serviced_at, type: String
+          optional :description, type: String
+          optional :deleted_at, type: String
+          optional :created_at, type: String
+          optional :updated_at, type: String
+          optional :uptime, type: Integer, documentation: { type: "Integer", desc: "Uptime in seconds" }
+          optional :serialnumber, type: String
+          optional :backup_type, type: Integer, documentation: { type: "Integer", desc: "Backup type" }
+          optional :auto_update, type: Boolean, documentation: { type: "Bool", desc: "true if the machine is updated automatically" }
+          optional :switch_url, type: String
+          optional :mrtg_url, type: String
+          optional :config_instructions, type: String
+          optional :sw_characteristics, type: String
+          optional :business_purpose, type: String
+          optional :business_criticality, type: String
+          optional :business_notification, type: String
+          optional :diskspace, documentation: { type: "Integer", desc: "Disc space in bytes" }
+          optional :severity_class, type: String
+          optional :ucs_role, type: String
+          optional :backup_brand, type: String
+          optional :backup_last_full_run, type: String, documentation: { type: "String", desc: "Name" }
+          optional :backup_last_inc_run, type: String, documentation: { type: "String", desc: "Name" }
+          optional :backup_last_diff_run, type: String, documentation: { type: "String", desc: "Name" }
+          optional :backup_last_full_size, type: String, documentation: { type: "String", desc: "Name" }
+          optional :backup_last_inc_size, type: String, documentation: { type: "String", desc: "Name" }
+          optional :backup_last_diff_size, type: String, documentation: { type: "String", desc: "Name" }
+          optional :needs_reboot, type: Integer
+          optional :software, type: JSON, documentation: { type: "JSON", desc: "Known installed doftware packages" }
+          optional :power_feed_a, documentation: { type: "Integer", desc: "Location id of power feed a" }
+          optional :power_feed_b, documentation: { type: "Integer", desc: "Location id of power feed b" }
+        end
         put do
           can_write!
           m = Machine.find_by_fqdn params[:fqdn]
           error!('Not Found', 404) unless m
 
-          p = params.select { |k| Machine.attribute_method?(k) }
-          error!('Update nics via nics subroute') if p['nics']
-
-          error!('Update aliases via aliases subroute') if p['aliases']
+          p = declared(params).to_h
 
           m.update_attributes(p)
 
@@ -280,9 +315,48 @@ module V3
       end
 
       desc 'Create a new machine', success: Machine::Entity
+      params do
+        requires :fqdn, type: String
+        optional :os, type: String
+        optional :os_release, type: String
+        optional :arch, type: String
+        optional :ram, type: Integer
+        optional :cores, type: Integer
+        optional :vmhost, type: String
+        optional :serviced_at, type: String
+        optional :description, type: String
+        optional :deleted_at, type: String
+        optional :created_at, type: String
+        optional :updated_at, type: String
+        optional :uptime, type: Integer, documentation: { type: "Integer", desc: "Uptime in seconds" }
+        optional :serialnumber, type: String
+        optional :backup_type, type: Integer, documentation: { type: "Integer", desc: "Backup type" }
+        optional :auto_update, type: Boolean, documentation: { type: "Bool", desc: "true if the machine is updated automatically" }
+        optional :switch_url, type: String
+        optional :mrtg_url, type: String
+        optional :config_instructions, type: String
+        optional :sw_characteristics, type: String
+        optional :business_purpose, type: String
+        optional :business_criticality, type: String
+        optional :business_notification, type: String
+        optional :diskspace, documentation: { type: "Integer", desc: "Disc space in bytes" }
+        optional :severity_class, type: String
+        optional :ucs_role, type: String
+        optional :backup_brand, type: String
+        optional :backup_last_full_run, type: String, documentation: { type: "String", desc: "Name" }
+        optional :backup_last_inc_run, type: String, documentation: { type: "String", desc: "Name" }
+        optional :backup_last_diff_run, type: String, documentation: { type: "String", desc: "Name" }
+        optional :backup_last_full_size, type: String, documentation: { type: "String", desc: "Name" }
+        optional :backup_last_inc_size, type: String, documentation: { type: "String", desc: "Name" }
+        optional :backup_last_diff_size, type: String, documentation: { type: "String", desc: "Name" }
+        optional :needs_reboot, type: Integer
+        optional :software, type: JSON, documentation: { type: "JSON", desc: "Known installed software packages" }
+        optional :power_feed_a, documentation: { type: "Integer", desc: "Location id of power feed a" }
+        optional :power_feed_b, documentation: { type: "Integer", desc: "Location id of power feed b" }
+      end
       post do
         can_write!
-        p = params.select { |k| Machine.attribute_method?(k) }
+        p = declared(params).to_h
         begin
           m = Machine.new(p)
           m.owner = @owner

--- a/spec/api/v3/cloud_provider_api_spec.rb
+++ b/spec/api/v3/cloud_provider_api_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+require 'api_helper'
+require 'fakeweb'
+require 'timecop'
+
+describe 'Cloud Provider API V3' do
+
+  before :each do
+    IDB.config.modules.api.v1_enabled = false
+    IDB.config.modules.api.v2_enabled = false
+    IDB.config.modules.api.v3_enabled = true
+
+    @owner = FactoryGirl.create(:owner, users: [FactoryGirl.create(:user)])
+    allow(User).to receive(:current).and_return(@owner.users.first)
+
+    FactoryGirl.create :cloud_provider, owner: @owner
+    FactoryGirl.create :api_token, owner: @owner
+    @api_token = FactoryGirl.build :api_token, owner: @owner
+    @api_token_r = FactoryGirl.create :api_token_r, owner: @owner
+    @api_token_w = FactoryGirl.create :api_token_w, owner: @owner
+
+    # prevent execution of VersionChangeWorker, depends on running sidekiq workers
+    allow(VersionChangeWorker).to receive(:perform_async) do |arg|
+      nil
+    end
+  end
+  
+  describe "API is switched off" do
+    it 'should not allow access' do
+      IDB.config.modules.api.v3_enabled = false
+
+      api_get(action: "cloud_providers", token: @api_token_r, version:"3")
+      expect(response.status).to eq(501)
+      expect(JSON.parse(response.body)).to eq({"response_type"=>"error", "response"=>"API disabled."})
+    end
+  end
+
+  describe "GET /cloud_providers but unauthorized" do
+    it 'should return json error message' do
+      api_get_unauthorized(action: "cloud_providers", version: "3")
+
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body)).to eq({"response_type"=>"error", "response"=>"Unauthorized."})
+    end
+  end
+
+  describe "GET /cloud_providers" do
+    it 'should return all cloud provider configurations' do
+      api_get(action: "cloud_providers", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      cloud_providers = JSON.parse(response.body)
+      expect(cloud_providers.size).to eq(1)
+      expect(cloud_providers[0]['name']).to eq(CloudProvider.last.name)
+    end
+  end
+
+  describe "GET /cloud_providers with header authorization" do
+    it 'should return all cloud provider configurations' do
+      api_get_auth_header(action: "cloud_providers", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      cloud_providers = JSON.parse(response.body)
+      expect(cloud_providers.size).to eq(1)
+      expect(cloud_providers[0]['name']).to eq(CloudProvider.last.name)
+    end
+  end
+
+  describe "GET /cloud_providers?fqdn=" do
+    it 'should filter cloud provider items for items with this name' do
+      api_get(action: "cloud_providers?name=#{CloudProvider.last.name}", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      cloud_provider = JSON.parse(response.body)
+      expect(cloud_provider.size).to eq(1)
+      expect(cloud_provider[0]['name']).to eq(CloudProvider.last.name)
+    end
+
+    it 'should return empty JSON array and if no switch item matches' do
+      api_get(action: "cloud_providers?name=not_existing", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      cloud_providers = JSON.parse(response.body)
+      expect(cloud_providers).to eq([])
+    end
+  end
+
+  describe "POST /cloud_providers" do
+    it 'creates a cloud provider' do
+      api_get(action: "cloud_providers/foobar", token: @api_token_r, version: "3")
+      cloud_provider = JSON.parse(response.body)
+      expect(cloud_provider).to eq("response_type"=>"error", "response"=>"Not found")
+
+      payload = {
+        "name":"foobar",
+        "config": "config"
+      }
+      api_post_json(action: "cloud_providers", token: @api_token_w, payload: payload, version: "3")
+      expect(response.status).to eq(201)
+
+      cloud_provider = JSON.parse(response.body)
+      expect(cloud_provider['name']).to eq("foobar")
+      expect(cloud_provider['config']).to eq("config")
+    end
+  end
+
+  describe "GET with wrong token permissions" do
+    it 'should return 401 Unauthorized' do
+      api_get(action: "cloud_providers", token: @api_token, version: "3")
+      expect(response.status).to eq(401)
+    end
+  end
+
+  describe "POST with wrong token permissions" do
+    it 'should return 401 Unauthorized' do
+      payload = {
+        "name":"foobar"
+      }
+      api_post_json(action: "cloud_providers", token: @api_token, payload: payload, version: "3")
+      expect(response.status).to eq(401)
+    end
+  end
+end
+

--- a/spec/api/v3/locations_api_spec.rb
+++ b/spec/api/v3/locations_api_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+require 'api_helper'
+require 'fakeweb'
+require 'timecop'
+
+describe 'Location API V3' do
+
+  before :each do
+    IDB.config.modules.api.v1_enabled = false
+    IDB.config.modules.api.v2_enabled = false
+    IDB.config.modules.api.v3_enabled = true
+
+    @owner = FactoryGirl.create(:owner, users: [FactoryGirl.create(:user)])
+    allow(User).to receive(:current).and_return(@owner.users.first)
+
+    FactoryGirl.create :location, owner: @owner
+    FactoryGirl.create :api_token, owner: @owner
+    @api_token = FactoryGirl.build :api_token, owner: @owner
+    @api_token_r = FactoryGirl.create :api_token_r, owner: @owner
+    @api_token_w = FactoryGirl.create :api_token_w, owner: @owner
+
+    # prevent execution of VersionChangeWorker, depends on running sidekiq workers
+    allow(VersionChangeWorker).to receive(:perform_async) do |arg|
+      nil
+    end
+  end
+  
+  describe "API is switched off" do
+    it 'should not allow access' do
+      IDB.config.modules.api.v3_enabled = false
+
+      api_get(action: "locations", token: @api_token_r, version:"3")
+      expect(response.status).to eq(501)
+      expect(JSON.parse(response.body)).to eq({"response_type"=>"error", "response"=>"API disabled."})
+    end
+  end
+
+  describe "GET /locations but unauthorized" do
+    it 'should return json error message' do
+      api_get_unauthorized(action: "locations", version: "3")
+
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body)).to eq({"response_type"=>"error", "response"=>"Unauthorized."})
+    end
+  end
+
+  describe "GET /locations" do
+    it 'should return all locations' do
+      api_get_auth_header(action: "locations", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      locations = JSON.parse(response.body)
+      expect(locations.size).to eq(1)
+      expect(locations[0]['name']).to eq(Location.last.name)
+    end
+  end
+
+  describe "GET /locations?name=" do
+    it 'should filter locations' do
+      api_get(action: "locations?name=#{Location.last.name}", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      location = JSON.parse(response.body)
+      expect(location.size).to eq(1)
+      expect(location[0]['name']).to eq(Location.last.name)
+    end
+
+    it 'should return empty JSON array if no item matches' do
+      api_get(action: "locations?name=not_existing", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      locations = JSON.parse(response.body)
+      expect(locations).to eq([])
+    end
+  end
+
+  describe "GET /locations/id/{id}" do
+    it 'should return a location by id' do
+      api_get(action: "locations/id/#{Location.last.id}", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      location = JSON.parse(response.body)
+      expect(location['name']).to eq(Location.last.name)
+    end
+  end
+
+  describe "GET /locations/roots" do
+    it 'should return all root locations' do
+      api_get(action: "locations/roots", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      locations = JSON.parse(response.body)
+      expect(locations.size).to eq(1)
+      expect(locations[0]["name"]).to eq(Location.last.name)
+    end
+  end
+
+  describe "POST /locations/roots" do
+    it 'creates a root location' do
+      payload = {
+        "name":"foobar"
+      }
+      api_post_json(action: "locations/roots", token: @api_token_w, payload: payload, version: "3")
+      expect(response.status).to eq(201)
+
+      location = JSON.parse(response.body)
+      expect(location['name']).to eq("foobar")
+    end
+  end
+
+  describe "GET with wrong token permissions" do
+    it 'should return 401 Unauthorized' do
+      api_get(action: "locations", token: @api_token, version: "3")
+      expect(response.status).to eq(401)
+    end
+  end
+
+  describe "POST with wrong token permissions" do
+    it 'should return 401 Unauthorized' do
+      payload = {
+        "name":"foobar"
+      }
+      api_post_json(action: "locations", token: @api_token, payload: payload, version: "3")
+      expect(response.status).to eq(401)
+    end
+  end
+end
+


### PR DESCRIPTION
this adds parameter declarations to (modifing) api routes to disallow things like raw_data_puppetdb, with the side effect of providing documentation with grape-swagger-entity