### PR TITLE
include inventory status string

### DIFF
--- a/app/api/v3/inventories.rb
+++ b/app/api/v3/inventories.rb
@@ -102,15 +102,7 @@ module V3
 
           p = declared(params).to_h
 
-          if p["inventory_status"]
-            s = InventoryStatus.find_by_name p["inventory_status"]
-            if s
-              p["inventory_status_id"] = s.id
-            else
-              p["inventory_status_id"] = nil
-            end
-          end
-
+          p["inventory_status_id"] = InventoryStatus.where(name: p["inventory_status"]).pluck(:id).first
           p.delete("inventory_status")
 
           i.update_attributes(p)
@@ -180,15 +172,7 @@ module V3
         can_write!
         p = declared(params).to_h
         
-        if p["inventory_status"]
-          s = InventoryStatus.find_by_name p["inventory_status"]
-          if s
-            p["inventory_status_id"] = s.id
-          else
-            p["inventory_status_id"] = nil
-          end
-        end
-
+        p["inventory_status_id"] = InventoryStatus.where(name: p["inventory_status"]).pluck(:id).first
         p.delete("inventory_status")
 
         i = Inventory.new(p)

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -61,6 +61,11 @@ class Inventory < ActiveRecord::Base
     expose :location_id, documentation: { type: "Integer", desc: "ID of the location" }
     expose :install_date, documentation: { type: "String", desc: "Installation date as YYYY-MM-DD" }
     expose :inventory_status_id, documentation: { type: "Integer", desc: "Inventory status id" } # FIXME
+    expose :inventory_status, documentation: { type: "String", desc: "Inventory status" }
+
+    def inventory_status
+      object.status_string
+    end
 
     def machine
       m = Machine.find_by_id(object.machine_id)


### PR DESCRIPTION
the inventory status string is now included as "inventory_status". "inventory_status_id" is not removed to not break the api. if "inventory_status" is set in an update / create request, it overrides the value of "inventory_status_id".