### PR TITLE
Chown symlinks in post install script

### DIFF
--- a/scripts/debian/postinst.sh
+++ b/scripts/debian/postinst.sh
@@ -25,20 +25,19 @@ if [ ! -d "$IDBETC/initializers" ]; then
   mkdir $IDBETC/initializers
 fi
 
-# copy selected initializers
-cp $IDBPATH/config-example/initializers/app_config.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/assets.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/backtrace_silencers.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/filter_parameter_logging.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/inflections.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/mime_types.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/paper_trail.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/raven.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/redis.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/rubius.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/session_store.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/sidekiq.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/simple_form.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/simple_form_bootstrap.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/version.rb $IDBETC/initializers
-cp $IDBPATH/config-example/initializers/wrap_parameters.rb $IDBETC/initializers
+# copy initializers
+for f in $IDBPATH/config-example/initializers/*; do
+  # don't overwrite existing initializers as they may be customized
+  cp -n $f $IDBETC/initializers
+done
+
+# copy config files
+for f in $IDBPATH/config-example/*; do
+  # don't overwrite existing configs
+  cp -n $f $IDBETC
+fi
+
+# fix ownership of config and symlinks
+chown -R idb:idb $IDBETC
+chown idb:idb $IDBPATH/config
+chown idb:idb $IDBPATH/log

--- a/scripts/debian/postinst.sh
+++ b/scripts/debian/postinst.sh
@@ -35,7 +35,7 @@ done
 for f in $IDBPATH/config-example/*; do
   # don't overwrite existing configs
   cp -n $f $IDBETC
-fi
+done
 
 # fix ownership of config and symlinks
 chown -R idb:idb $IDBETC

--- a/scripts/debian/postinst.sh
+++ b/scripts/debian/postinst.sh
@@ -20,21 +20,10 @@ fi
 # create symlink to config
 ln -s $IDBETC $IDBPATH/config
 
-# check if initializers dir exists, create if not
-if [ ! -d "$IDBETC/initializers" ]; then
-  mkdir $IDBETC/initializers
-fi
-
-# copy initializers
-for f in $IDBPATH/config-example/initializers/*; do
-  # don't overwrite existing initializers as they may be customized
-  cp -n $f $IDBETC/initializers
-done
-
 # copy config files
 for f in $IDBPATH/config-example/*; do
   # don't overwrite existing configs
-  cp -n $f $IDBETC
+  cp -nR $f $IDBETC
 done
 
 # fix ownership of config and symlinks


### PR DESCRIPTION
chown symlinks to configuration and log directory. don't copy example config over existing config.