### PR TITLE
add new routes to manage deleted objects

### DIFF
--- a/app/api/v3/api.rb
+++ b/app/api/v3/api.rb
@@ -9,6 +9,7 @@ module V3
     mount V3::Switches
     mount V3::Nics
     mount V3::Locations
+    mount V3::Deleted
     add_swagger_documentation mount_path: '/v3/swagger_doc', base_path: '/api', add_base_path: true, models: [Machine::Entity], info: { title: 'IDB API', description: 'Infrastructure Database v3', contact_name: 'bytemine GmbH', contact_email: 'support@bytemine.net', contact_url: 'https://bytemine.net', license: 'GNU AFFERO GENERAL PUBLIC LICENSE Version 3', license_url: 'https://www.gnu.org/licenses/agpl-3.0.txt' }
   end
 end

--- a/app/api/v3/deleted.rb
+++ b/app/api/v3/deleted.rb
@@ -1,0 +1,81 @@
+module V3
+    class Deleted < Grape::API
+      helpers V3::Helpers
+  
+      version 'v3'
+      format :json
+  
+      resource :deleted do
+        before do
+          api_enabled!
+          authenticate!
+          set_papertrail
+          @owner = get_owner
+        end
+  
+        resource :machines do
+            route_param :fqdn, type: String, requirements: { fqdn: /[a-zA-Z0-9.-]+/ } do
+                desc 'Get a deleted machine by fqdn', success: Machine::Entity
+                get do
+                  can_read!
+                  m = Machine.owned_by(@owner).only_deleted.find_by_fqdn params[:fqdn]
+                  error!('Not Found', 404) unless m
+        
+                  present m
+                end
+
+                desc 'Undelete a machine'
+                post do
+                  can_write!
+                  m = Machine.owned_by(@owner).only_deleted.find_by_fqdn params[:fqdn]
+                  error!('Not Found', 404) unless m
+        
+                  m.restore
+                  redirect '/machines/'+m.fqdn
+                end
+
+                desc 'Finally delete a machine'
+                delete do
+                    can_write!
+                    m = Machine.owned_by(@owner).only_deleted.find_by_fqdn params[:fqdn]
+                    error!('Not Found', 404) unless m
+                    m.really_destroy!
+                  end
+            end
+
+            desc 'Return a list of deleted machines, possibly filtered', is_array: true,
+                                                                 success: Machine::Entity
+            get do
+                can_read!
+
+                # first get all machines
+                query = Machine.owned_by(@owner).only_deleted
+
+                # strip possible idb_api_token parameter, this isn't a key of machines
+                params.delete('idb_api_token')
+
+                # then add a where condition for each parameter of the request
+                params.each do |key, value|
+                # arel_table uses symbols to get a symbol from the key string
+                keysym = key.to_sym
+                # merge AND connects the next "where" condition, which is build using arel_table of Machine
+                # (http://www.rubydoc.info/github/rails/arel/Arel/Table)
+                query = query.merge(Machine.where(Machine.arel_table[keysym].eq(value)))
+                end
+
+                # test if there were any keys which are no column names.
+                # otherwise the exception would be thrown when rendering.
+                # return 400 for such a request.
+                begin
+                error!('Not Found', 404) unless query.any?
+                rescue ActiveRecord::StatementInvalid
+                error!('Bad Request', 400)
+                end
+
+                present query
+            end
+        end
+      end
+    end
+  end
+  


### PR DESCRIPTION
i added a new route "/deleted" to contain subroutes for deleted objects.

currently only "/deleted/machines" exists.
it has functionality to query, restore and finally delete machines.