### PR TITLE
fix missing type for machines

### DIFF
--- a/db/migrate/20171019105531_fix_missing_type_for_machines.rb
+++ b/db/migrate/20171019105531_fix_missing_type_for_machines.rb
@@ -1,0 +1,8 @@
+class FixMissingTypeForMachines < ActiveRecord::Migration[5.0]
+  def change
+    Machine.where(type: nil).each do |m|
+      m.type = "Machine"
+      m.save!
+    end
+  end
+end


### PR DESCRIPTION
while converting from device_type_id to single table inheritance with
different classes for the different machine types, the migration did
not set the type to "Machine" when device_type_id was set to 1. to fix
this, set all Machines which have to type set to type "Machine".