### PR TITLE
fix vmhost listing

### DIFF
--- a/app/forms/editable_machine_form.rb
+++ b/app/forms/editable_machine_form.rb
@@ -140,7 +140,7 @@ class EditableMachineForm
   end
 
   def vmhost_list
-    Machine.where("type = 'Machine'")
+    Machine.where("type = 'Machine'").pluck(:fqdn).sort
   end
 
   def os_list


### PR DESCRIPTION
vmhost_list returned a list of machine objects, resulting in
vmhost being set to an id instead of a name. return to a list
of fqdns again.