### PR TITLE
really fix single table inheritance

### DIFF
--- a/app/forms/editable_machine_form.rb
+++ b/app/forms/editable_machine_form.rb
@@ -140,7 +140,7 @@ class EditableMachineForm
   end
 
   def vmhost_list
-    Machine.where(type: nil).pluck(:fqdn).sort
+    Machine.where(type: "Machine").or(Machine.where(type: nil)).pluck(:fqdn).map(&:downcase).sort
   end
 
   def os_list

--- a/app/forms/editable_machine_form.rb
+++ b/app/forms/editable_machine_form.rb
@@ -140,7 +140,7 @@ class EditableMachineForm
   end
 
   def vmhost_list
-    Machine.where("type = 'Machine'").pluck(:fqdn).sort
+    Machine.where(type: nil).pluck(:fqdn).sort
   end
 
   def os_list

--- a/db/migrate/20171019144401_fix_single_table_inheritance.rb
+++ b/db/migrate/20171019144401_fix_single_table_inheritance.rb
@@ -1,0 +1,15 @@
+class FixSingleTableInheritance < ActiveRecord::Migration[5.0]
+  def up
+    Machine.where(type: "Machine").each do |m|
+      m.type = nil
+      m.save!
+    end
+  end
+
+  def down
+    Machine.where(type: nil).each do |m|
+      m.type = "Machine"
+      m.save!
+    end
+  end
+end


### PR DESCRIPTION
turns out that sti sets type to nil if the base class is used. to fix this:
- set "type" attribute of all Machine (the base class) objects to nil.
- select all Machines with type nil in vmhost_list, instead of searching for type "Machine"