### PR TITLE
5229 multiple tokens

### DIFF
--- a/app/api/v3/cloud_providers.rb
+++ b/app/api/v3/cloud_providers.rb
@@ -11,6 +11,7 @@ module V3
         authenticate!
         set_papertrail
         @owner = get_owner
+        @owners = get_owners
       end
 
       route_param :rname, type: String, requirements: { name: /[a-zA-Z0-9.]+/ } do
@@ -18,7 +19,7 @@ module V3
           success: CloudProvider::Entity
         get do
           can_read!
-          c = CloudProvider.owned_by(@owner).find_by_name params[:rname]
+          c = CloudProvider.owned_by(@owners).find_by_name params[:rname]
           error!('Not found', 404) unless c
 
           present c
@@ -54,7 +55,7 @@ module V3
       get do
         can_read!
 
-        query = CloudProvider.owned_by(@owner).all
+        query = CloudProvider.owned_by(@owners).all
         params.delete('idb_api_token')
         params.each do |key, value|
           keysym = key.to_sym

--- a/app/api/v3/cloud_providers.rb
+++ b/app/api/v3/cloud_providers.rb
@@ -22,7 +22,7 @@ module V3
           c = CloudProvider.owned_by(@owners).find_by_name params[:rname]
           error!('Not found', 404) unless c
 
-          set_token item_token(c)
+          set_token item_update_token(c)
 
           present c
         end

--- a/app/api/v3/cloud_providers.rb
+++ b/app/api/v3/cloud_providers.rb
@@ -22,6 +22,8 @@ module V3
           c = CloudProvider.owned_by(@owners).find_by_name params[:rname]
           error!('Not found', 404) unless c
 
+          set_token item_token(c)
+
           present c
         end
 

--- a/app/api/v3/deleted.rb
+++ b/app/api/v3/deleted.rb
@@ -11,7 +11,7 @@ module V3
           authenticate!
           set_papertrail
           @owner = get_owner
-          @owners = get_owner
+          @owners = get_owners
         end
   
         resource :machines do

--- a/app/api/v3/deleted.rb
+++ b/app/api/v3/deleted.rb
@@ -11,6 +11,7 @@ module V3
           authenticate!
           set_papertrail
           @owner = get_owner
+          @owners = get_owner
         end
   
         resource :machines do
@@ -18,7 +19,7 @@ module V3
                 desc 'Get a deleted machine by fqdn', success: Machine::Entity
                 get do
                   can_read!
-                  m = Machine.owned_by(@owner).only_deleted.find_by_fqdn params[:fqdn]
+                  m = Machine.owned_by(@owners).only_deleted.find_by_fqdn params[:fqdn]
                   error!('Not Found', 404) unless m
         
                   present m
@@ -49,7 +50,7 @@ module V3
                 can_read!
 
                 # first get all machines
-                query = Machine.owned_by(@owner).only_deleted
+                query = Machine.owned_by(@owners).only_deleted
 
                 # strip possible idb_api_token parameter, this isn't a key of machines
                 params.delete('idb_api_token')

--- a/app/api/v3/deleted.rb
+++ b/app/api/v3/deleted.rb
@@ -22,6 +22,8 @@ module V3
                   m = Machine.owned_by(@owners).only_deleted.find_by_fqdn params[:fqdn]
                   error!('Not Found', 404) unless m
         
+                  set_token item_token(m)
+
                   present m
                 end
 

--- a/app/api/v3/helpers.rb
+++ b/app/api/v3/helpers.rb
@@ -6,44 +6,48 @@ module V3
       unless IDB.config.modules.api.v3_enabled
         error!("API disabled.", 501)
       end
-     end
+    end
 
-    def get_token
-      if params[:idb_api_token]
-        return params[:idb_api_token]
-      elsif request.headers["X-Idb-Api-Token"]
-        return request.headers["X-Idb-Api-Token"]
-      else
-        error!("Unauthorized.", 401)
-      end
+    def get_tokens
+      request.headers["X-Idb-Api-Token"].split(",").map{ |x| x.strip }
     end
 
     def authenticate!
-      token = params[:idb_api_token] ? params[:idb_api_token] : request.headers["X-Idb-Api-Token"]
-      if ApiToken.where("token = ?", token).empty?
-        error!("Unauthorized.", 401)
+      tokens = get_tokens
+      tokens.each do |t|
+        if ApiToken.where("token = ?", t).empty?
+          error!("Unauthorized.", 401)
+        end
       end
     end
 
     def can_read!
-      token = params[:idb_api_token] ? params[:idb_api_token] : request.headers["X-Idb-Api-Token"]
-      unless ApiToken.where("token = ?", token).first.read
-        error!("Unauthorized.", 401)
+      tokens = get_tokens
+      tokens.each do |t|
+        unless ApiToken.where("token = ?", t).first.read
+          error!("Unauthorized.", 401)
+        end
       end
     end
 
     def can_write!
-      token = params[:idb_api_token] ? params[:idb_api_token] : request.headers["X-Idb-Api-Token"]
+      token = get_tokens.first.to_s
       unless ApiToken.where("token = ?", token).first.write
         error!("Unauthorized.", 401)
       end
     end
 
     def get_owner
-      token = params[:idb_api_token] ? params[:idb_api_token] : request.headers["X-Idb-Api-Token"]
+      token = get_tokens.first.to_s
       x = ApiToken.find_by_token token
 
       return Owner.find_by_id x.owner_id
+    end
+
+    def get_owners
+      tokens = get_tokens
+      owners = tokens.map{ |t| Owner.find_by_id(ApiToken.find_by_token(t).owner_id) }
+      owners.uniq
     end
 
     def set_papertrail

--- a/app/api/v3/helpers.rb
+++ b/app/api/v3/helpers.rb
@@ -15,6 +15,22 @@ module V3
       request.headers["X-Idb-Api-Token"].split(",").map{ |x| x.strip }
     end
 
+    def set_token(t)
+      header "X-Idb-Api-Token", t
+    end
+
+    # select the first valid token for updating this item
+    # return nil if no token matches
+    def item_token(item)
+      get_tokens.each do |t|
+        x = ApiToken.find_by_token(t)
+        if x.owner == item.owner && x.write
+          return t
+        end
+      end
+      nil
+    end
+
     def authenticate!
       tokens = get_tokens
       tokens.each do |t|

--- a/app/api/v3/inventories.rb
+++ b/app/api/v3/inventories.rb
@@ -78,7 +78,7 @@ module V3
           i = Inventory.owned_by(@owners).find_by_inventory_number params[:inventory_number]
           error!('Not found', 404) unless i
 
-          set_token item_token(i)
+          set_token item_update_token(i)
 
           present i
         end

--- a/app/api/v3/inventories.rb
+++ b/app/api/v3/inventories.rb
@@ -78,6 +78,8 @@ module V3
           i = Inventory.owned_by(@owners).find_by_inventory_number params[:inventory_number]
           error!('Not found', 404) unless i
 
+          set_token item_token(i)
+
           present i
         end
 

--- a/app/api/v3/inventories.rb
+++ b/app/api/v3/inventories.rb
@@ -11,6 +11,7 @@ module V3
         authenticate!
         set_papertrail
         @owner = get_owner
+        @owners = get_owners
       end
 
       route_param :inventory_number, type: String do
@@ -20,7 +21,7 @@ module V3
               success: Attachment::Entity
             get do
               can_read!
-              a = Attachment.owned_by(@owner).find_by_attachment_fingerprint params[:fingerprint]
+              a = Attachment.owned_by(@owners).find_by_attachment_fingerprint params[:fingerprint]
               error!('Not Found', 404) unless a
 
               present a
@@ -42,7 +43,7 @@ module V3
             success: Attachment::Entity
           get do
             can_read!
-            i = Inventory.owned_by(@owner).find_by_inventory_number params[:inventory_number]
+            i = Inventory.owned_by(@owners).find_by_inventory_number params[:inventory_number]
             error!('Not Found', 404) unless i
 
             present i.attachments
@@ -74,7 +75,7 @@ module V3
           success: Inventory::Entity
         get do
           can_read!
-          i = Inventory.owned_by(@owner).find_by_inventory_number params[:inventory_number]
+          i = Inventory.owned_by(@owners).find_by_inventory_number params[:inventory_number]
           error!('Not found', 404) unless i
 
           present i
@@ -124,7 +125,7 @@ module V3
         end
         params.delete 'machine'
 
-        query = Inventory.owned_by(@owner).all
+        query = Inventory.owned_by(@owners).all
         params.delete('idb_api_token')
         params.each do |key, value|
           keysym = key.to_sym

--- a/app/api/v3/locations.rb
+++ b/app/api/v3/locations.rb
@@ -22,7 +22,7 @@ module V3
             l = Location.owned_by(@owners).find_by_id params[:id]
             error!('Not Found', 404) unless l
 
-            set_token item_token(l)
+            set_token item_update_token(l)
 
             l
           end

--- a/app/api/v3/locations.rb
+++ b/app/api/v3/locations.rb
@@ -22,6 +22,8 @@ module V3
             l = Location.owned_by(@owners).find_by_id params[:id]
             error!('Not Found', 404) unless l
 
+            set_token item_token(l)
+
             l
           end
 

--- a/app/api/v3/locations.rb
+++ b/app/api/v3/locations.rb
@@ -11,6 +11,7 @@ module V3
         authenticate!
         set_papertrail
         @owner = get_owner
+        @owners = get_owners
       end
 
       resource :id do
@@ -18,7 +19,7 @@ module V3
           desc 'Get location by id',
             success: Location::Entity
           get do
-            l = Location.owned_by(@owner).find_by_id params[:id]
+            l = Location.owned_by(@owners).find_by_id params[:id]
             error!('Not Found', 404) unless l
 
             l
@@ -76,7 +77,7 @@ module V3
           success: Location::Entity
         get do
           can_read!
-          Location.owned_by(@owner).roots.sort_by(&:name)
+          Location.owned_by(@owners).roots.sort_by(&:name)
         end
 
         desc 'Create a new location root',
@@ -100,7 +101,7 @@ module V3
         get do
           can_read!
 
-          query = LocationLevel.owned_by(@owner).all
+          query = LocationLevel.owned_by(@owners).all
           params.delete('idb_api_token')
           params.each do |key, value|
             keysym = key.to_sym
@@ -124,15 +125,15 @@ module V3
         can_read!
 
         if params['level']
-          if LocationLevel.owned_by(@owner).find_by_level(params['level'])
-            params[:location_level_id] = LocationLevel.owned_by(@owner).find_by_level(params['level']).id
+          if LocationLevel.owned_by(@owners).find_by_level(params['level'])
+            params[:location_level_id] = LocationLevel.owned_by(@owners).find_by_level(params['level']).id
           else
             return []
           end
         end
         params.delete 'level'
 
-        query = Location.owned_by(@owner).all
+        query = Location.owned_by(@owners).all
         params.delete('idb_api_token')
         params.each do |key, value|
           keysym = key.to_sym

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -347,7 +347,7 @@ module V3
         can_read!
 
         # first get all machines
-        query = Machine.where(owner: @owners).all
+        query = Machine.owned_by(@owners).all
 
         # strip possible idb_api_token parameter, this isn't a key of machines
         params.delete('idb_api_token')

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -8,10 +8,12 @@ module V3
 
     resource :machines do
       before do
+        puts "######################################"
+        puts get_owners
         api_enabled!
         authenticate!
         set_papertrail
-        @owner = get_owner
+        @owner = get_owners
       end
 
       route_param :rfqdn, type: String, requirements: { rfqdn: /.+/ } do

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -223,6 +223,8 @@ module V3
           m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
           error!('Not Found', 404) unless m
 
+          set_token item_token(m)
+
           present m
         end
 

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -8,12 +8,11 @@ module V3
 
     resource :machines do
       before do
-        puts "######################################"
-        puts get_owners
         api_enabled!
         authenticate!
         set_papertrail
-        @owner = get_owners
+        @owners = get_owners
+        @owner = get_owner
       end
 
       route_param :rfqdn, type: String, requirements: { rfqdn: /.+/ } do
@@ -24,7 +23,7 @@ module V3
             end
             get do
               can_read!
-              a = Attachment.owned_by(@owner).find_by_attachment_fingerprint params[:fingerprint]
+              a = Attachment.owned_by(@owners).find_by_attachment_fingerprint params[:fingerprint]
               error!('Not Found', 404) unless a
 
               present a
@@ -46,7 +45,7 @@ module V3
             success: Attachment::Entity
           get do
             can_read!
-            m = Machine.owned_by(@owner).find_by_fqdn params[:rfqdn]
+            m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
             error!('Not Found', 404) unless m
 
             present m.attachments
@@ -116,7 +115,7 @@ module V3
             success: MachineAlias::Entity
           get do
             can_read!
-            m = Machine.owned_by(@owner).find_by_fqdn params[:rfqdn]
+            m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
             error!('Not Found', 404) unless m
 
             present m.aliases
@@ -144,7 +143,7 @@ module V3
               success: Nic::Entity
             get do
               can_read!
-              m = Machine.owned_by(@owner).find_by_fqdn params[:rfqdn]
+              m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
               error!('Not Found', 404) unless m
 
               n = Nic.where(machine_id: m.id, name: params[:rnic])
@@ -189,7 +188,7 @@ module V3
             success: Nic::Entity
           get do
             can_read!
-            m = Machine.owned_by(@owner).find_by_fqdn params[:rfqdn]
+            m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
             error!('Not Found', 404) unless m
 
             present m.nics
@@ -221,7 +220,7 @@ module V3
           success: Machine::Entity
         get do
           can_read!
-          m = Machine.owned_by(@owner).find_by_fqdn params[:rfqdn]
+          m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
           error!('Not Found', 404) unless m
 
           present m
@@ -231,8 +230,9 @@ module V3
           params: Machine::Entity.documentation,
           success: Machine::Entity
         put do
-          can_write!
+          tok = can_write!
           m = Machine.owned_by(@owner).find_by_fqdn params[:rfqdn]
+
           error!('Not Found', 404) unless m
                     
           # move route parameter to params
@@ -245,11 +245,10 @@ module V3
             error!('Invalid Machine', 409)
           end
 
-          tok = get_token
           if m.raw_data_api
-            params['raw_data_api'] = JSON.parse(m.raw_data_api).merge({tok => params}).to_json
+            params['raw_data_api'] = JSON.parse(m.raw_data_api).merge({tok.name => params}).to_json
           else
-            params['raw_data_api'] = {tok => params}.to_json
+            params['raw_data_api'] = {tok.name => params}.to_json
           end
 
           begin
@@ -348,7 +347,7 @@ module V3
         can_read!
 
         # first get all machines
-        query = Machine.owned_by(@owner).all
+        query = Machine.where(owner: @owners).all
 
         # strip possible idb_api_token parameter, this isn't a key of machines
         params.delete('idb_api_token')
@@ -378,14 +377,13 @@ module V3
         params: Machine::Entity.documentation,
         success: Machine::Entity
       post do
-        can_write!
+        tok = can_write!
 
         if not Machine::FQDN_REGEX.match(params['fqdn'])
           error!('Invalid Machine', 409)
         end
 
-        tok = get_token
-        params['raw_data_api'] = {tok => params}.to_json
+        params['raw_data_api'] = {tok.name => params}.to_json
 
         begin
           m = Machine.new(params)

--- a/app/api/v3/machines.rb
+++ b/app/api/v3/machines.rb
@@ -223,7 +223,7 @@ module V3
           m = Machine.owned_by(@owners).find_by_fqdn params[:rfqdn]
           error!('Not Found', 404) unless m
 
-          set_token item_token(m)
+          set_token item_update_token(m)
 
           present m
         end

--- a/app/api/v3/maintenance_records.rb
+++ b/app/api/v3/maintenance_records.rb
@@ -106,7 +106,7 @@ module V3
                     
                     r = MaintenanceRecord.find_by_machine_id_and_created_at(m.id, params[:rcreated_at])
 
-                    set_token item_token(m)
+                    set_token item_update_token(m)
 
                     present r
                 end

--- a/app/api/v3/maintenance_records.rb
+++ b/app/api/v3/maintenance_records.rb
@@ -105,6 +105,9 @@ module V3
                     end
                     
                     r = MaintenanceRecord.find_by_machine_id_and_created_at(m.id, params[:rcreated_at])
+
+                    set_token item_token(m)
+
                     present r
                 end
             end

--- a/app/api/v3/nics.rb
+++ b/app/api/v3/nics.rb
@@ -21,6 +21,8 @@ module V3
           n = Nic.owned_by(@owners).find_by_id params[:id]
           error!('Not found', 404) unless n
 
+          set_token item_token(n)
+
           n
         end
 

--- a/app/api/v3/nics.rb
+++ b/app/api/v3/nics.rb
@@ -11,13 +11,14 @@ module V3
         authenticate!
         set_papertrail
         @owner = get_owner
+        @owners = get_owners
       end
 
       route_param :id, type: Integer, requirements: { id: /[0-9]+/ } do
         desc 'Get a nic by id', success: Nic::Entity
         get do
           can_read!
-          n = Nic.owned_by(@owner).find_by_id params[:id]
+          n = Nic.owned_by(@owners).find_by_id params[:id]
           error!('Not found', 404) unless n
 
           n
@@ -55,8 +56,8 @@ module V3
         can_read!
 
         if params['machine']
-          if Machine.owned_by(@owner).find_by_fqdn(params['machine'])
-            params[:machine_id] = Machine.owned_by(@owner).find_by_fqdn(params['machine']).id
+          if Machine.owned_by(@owners).find_by_fqdn(params['machine'])
+            params[:machine_id] = Machine.owned_by(@owners).find_by_fqdn(params['machine']).id
           else
             return []
           end
@@ -79,7 +80,7 @@ module V3
 
         nics = Array.new()
         query.each do |n|
-          if n.machine and n.machine.owner == @owner
+          if n.machine and @owners.include? n.machine.owner
             nics << n
           end
         end

--- a/app/api/v3/nics.rb
+++ b/app/api/v3/nics.rb
@@ -18,10 +18,13 @@ module V3
         desc 'Get a nic by id', success: Nic::Entity
         get do
           can_read!
-          n = Nic.owned_by(@owners).find_by_id params[:id]
+          # owned_by scope doesn't work with joins and IN conditions
+          n = Nic.where(id: params[:id]).first
           error!('Not found', 404) unless n
-
-          set_token item_token(n)
+          m = Machine.owned_by(@owners).find_by_id(n.machine_id)
+          error!('Not found', 404) unless m
+    
+          set_token item_update_token(m)
 
           n
         end

--- a/app/api/v3/softwares.rb
+++ b/app/api/v3/softwares.rb
@@ -10,6 +10,7 @@ module V3
         api_enabled!
         authenticate!
         @owner = get_owner
+        @owners = get_owners
       end
 
       desc 'Searches machines with specific software configurations', is_array: true,
@@ -28,7 +29,7 @@ module V3
             status 200
             []
           end
-          machines = SoftwareHelper.software_machines(Machines.owned_by(@owner), software, versions)
+          machines = SoftwareHelper.software_machines(Machine.owned_by(@owners), software, versions)
           status 200
           machines.map(&:fqdn)
         end

--- a/app/api/v3/switches.rb
+++ b/app/api/v3/switches.rb
@@ -14,46 +14,15 @@ module V3
         @owners = get_owners
       end
 
-      route_param :fqdn, type: String, requirements: { fqdn: /[a-zA-Z0-9.]+/ } do
-        desc 'Get a switch by fqdn',
-          success: Switch::Entity
-        get do
-          can_read!
-          s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
-          error!('Not found', 404) unless s
-
-          set_token item_token(s)
-
-          present s
-        end
-
-        desc 'Update a switch',
-          success: Switch::Entity
-        put do
-          can_write!
-          s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
-          error!('Not found', 404) unless s
-          
-          p = declared(params).to_h
-          s.update_attributes(p)
-          present s
-        end
-
-        desc 'Delete a switch'
-        delete do
-          can_write!
-          s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
-          error!('Not found', 404) unless s
-          s.destroy
-        end
-
+      route_param :rfqdn, type: String, requirements: { rfqdn: /.+/ } do
         resource :ports do
           route_param :number, type: Integer, requirements: { number: /[0-9]+/ } do
             desc 'Get a switch port',
               success: SwitchPort::Entity
             get do
+              puts "GET /switches/fqdn/ports/number"
               can_read!
-              s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
+              s = Switch.owned_by(@owners).find_by_fqdn params[:rfqdn]
               error!('Not found', 404) unless s
 
               p = SwitchPort.find_by number: params[:number], switch_id: s.id
@@ -66,8 +35,8 @@ module V3
               success: SwitchPort::Entity
             put do
               can_write!
-              s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
-              error!('Not found', 404) unless s
+              s = Switch.owned_by(@owner).find_by_fqdn params[:rfqdn]
+              error!('Not found 1', 404) unless s
 
               m = Machine.owned_by(@owner).find_by_fqdn params[:machine]
               error!('Machine not found', 404) unless m
@@ -98,7 +67,7 @@ module V3
           desc 'Return a list of switch ports', is_array: true, success: SwitchPort::Entity
           get do
             can_read!
-            s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
+            s = Switch.owned_by(@owners).find_by_fqdn params[:rfqdn]
             error!('Not found', 404) unless s
 
             present SwitchPort.where(switch_id: s.id)
@@ -109,7 +78,7 @@ module V3
             success: SwitchPort::Entity
           post do
             can_write!
-            s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
+            s = Switch.owned_by(@owner).find_by_fqdn params[:rfqdn]
             error!('Switch not found', 404) unless s
 
             m = Machine.owned_by(@owner).find_by_fqdn params[:machine]
@@ -123,6 +92,39 @@ module V3
             port = SwitchPort.create(p)
             present port
           end
+        end
+
+        desc 'Get a switch by fqdn',
+          success: Switch::Entity
+        get do
+          puts "GET /switches/fqdn"
+          can_read!
+          s = Switch.owned_by(@owners).find_by_fqdn params[:rfqdn]
+          error!('Not found', 404) unless s
+
+          set_token item_update_token(s)
+
+          present s
+        end
+
+        desc 'Update a switch',
+          success: Switch::Entity
+        put do
+          can_write!
+          s = Switch.owned_by(@owner).find_by_fqdn params[:rfqdn]
+          error!('Not found', 404) unless s
+          
+          p = declared(params).to_h
+          s.update_attributes(p)
+          present s
+        end
+
+        desc 'Delete a switch'
+        delete do
+          can_write!
+          s = Switch.owned_by(@owner).find_by_fqdn params[:rfqdn]
+          error!('Not found', 404) unless s
+          s.destroy
         end
       end
 

--- a/app/api/v3/switches.rb
+++ b/app/api/v3/switches.rb
@@ -22,6 +22,8 @@ module V3
           s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
           error!('Not found', 404) unless s
 
+          set_token item_token(s)
+
           present s
         end
 

--- a/app/api/v3/switches.rb
+++ b/app/api/v3/switches.rb
@@ -20,7 +20,6 @@ module V3
             desc 'Get a switch port',
               success: SwitchPort::Entity
             get do
-              puts "GET /switches/fqdn/ports/number"
               can_read!
               s = Switch.owned_by(@owners).find_by_fqdn params[:rfqdn]
               error!('Not found', 404) unless s
@@ -97,7 +96,6 @@ module V3
         desc 'Get a switch by fqdn',
           success: Switch::Entity
         get do
-          puts "GET /switches/fqdn"
           can_read!
           s = Switch.owned_by(@owners).find_by_fqdn params[:rfqdn]
           error!('Not found', 404) unless s

--- a/app/api/v3/switches.rb
+++ b/app/api/v3/switches.rb
@@ -11,6 +11,7 @@ module V3
         authenticate!
         set_papertrail
         @owner = get_owner
+        @owners = get_owners
       end
 
       route_param :fqdn, type: String, requirements: { fqdn: /[a-zA-Z0-9.]+/ } do
@@ -18,7 +19,7 @@ module V3
           success: Switch::Entity
         get do
           can_read!
-          s = Switch.find_by_fqdn params[:fqdn]
+          s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
           error!('Not found', 404) unless s
 
           present s
@@ -28,7 +29,7 @@ module V3
           success: Switch::Entity
         put do
           can_write!
-          s = Switch.find_by_fqdn params[:fqdn]
+          s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
           error!('Not found', 404) unless s
           
           p = declared(params).to_h
@@ -39,7 +40,7 @@ module V3
         desc 'Delete a switch'
         delete do
           can_write!
-          s = Switch.find_by_fqdn params[:fqdn]
+          s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
           error!('Not found', 404) unless s
           s.destroy
         end
@@ -50,7 +51,7 @@ module V3
               success: SwitchPort::Entity
             get do
               can_read!
-              s = Switch.find_by_fqdn params[:fqdn]
+              s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
               error!('Not found', 404) unless s
 
               p = SwitchPort.find_by number: params[:number], switch_id: s.id
@@ -63,10 +64,10 @@ module V3
               success: SwitchPort::Entity
             put do
               can_write!
-              s = Switch.find_by_fqdn params[:fqdn]
+              s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
               error!('Not found', 404) unless s
 
-              m = Machine.find_by_fqdn params[:machine]
+              m = Machine.owned_by(@owner).find_by_fqdn params[:machine]
               error!('Machine not found', 404) unless m
 
               n = Nic.find_by(name: params[:nic], machine: m.id)
@@ -95,7 +96,7 @@ module V3
           desc 'Return a list of switch ports', is_array: true, success: SwitchPort::Entity
           get do
             can_read!
-            s = Switch.find_by_fqdn params[:fqdn]
+            s = Switch.owned_by(@owners).find_by_fqdn params[:fqdn]
             error!('Not found', 404) unless s
 
             present SwitchPort.where(switch_id: s.id)
@@ -106,10 +107,10 @@ module V3
             success: SwitchPort::Entity
           post do
             can_write!
-            s = Switch.find_by_fqdn params[:fqdn]
+            s = Switch.owned_by(@owner).find_by_fqdn params[:fqdn]
             error!('Switch not found', 404) unless s
 
-            m = Machine.find_by_fqdn params[:machine]
+            m = Machine.owned_by(@owner).find_by_fqdn params[:machine]
             error!('Machine not found', 404) unless m
 
             n = Nic.find_by(name: params[:nic], machine: m.id)
@@ -127,7 +128,7 @@ module V3
       get do
         can_read!
 
-        query = Switch.all
+        query = Switch.owned_by(@owners).all
         params.delete('idb_api_token')
         params.each do |key, value|
           keysym = key.to_sym
@@ -148,7 +149,7 @@ module V3
         success: Switch::Entity
       post do
         can_write!
-        if Switch.find_by_fqdn params['fqdn']
+        if Switch.owned_by(@owner).find_by_fqdn params['fqdn']
           error!('Entry with this FQDN already exists.', 409)
         end
 

--- a/app/models/nic.rb
+++ b/app/models/nic.rb
@@ -6,7 +6,7 @@ class Nic < ActiveRecord::Base
   has_one :switch_port, dependent: :destroy, autosave: true
 
   def self.owned_by(o)
-    includes(:machine).where("machines.owner_id": o.id)
+    joins(:machine).where(machine: { owner: o })
   end
 
   before_save do |record|

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -9,6 +9,7 @@ class Owner < ActiveRecord::Base
   has_many :machines, :dependent => :destroy
   has_many :attachments, :dependent => :destroy
   has_many :cloud_providers, :dependent => :destroy
+  has_many :api_tokens, :dependent => :destroy
   has_and_belongs_to_many :users
 
   validates :name, :nickname, presence: true

--- a/spec/api/v2/machines_api_spec.rb
+++ b/spec/api/v2/machines_api_spec.rb
@@ -53,17 +53,6 @@ describe 'Machines API' do
     end
   end
 
-  describe "GET /machines with header authorization" do
-    it 'should return all machines' do
-      api_get_auth_header(action: "machines", token: @api_token_r)
-      expect(response.status).to eq(200)
-
-      machines = JSON.parse(response.body)
-      expect(machines.size).to eq(1)
-      expect(machines[0]['fqdn']).to eq(Machine.last.fqdn)
-    end
-  end
-
   describe "GET /machines?fqdn=" do
     it 'should return the corresponding machine' do
       api_get(action: "machines?fqdn=#{Machine.last.fqdn}", token: @api_token_r)

--- a/spec/api/v3/cloud_provider_api_spec.rb
+++ b/spec/api/v3/cloud_provider_api_spec.rb
@@ -74,10 +74,39 @@ describe 'Cloud Provider API V3' do
       expect(cps[0]['name']).to eq(CloudProvider.first.name)
       expect(cps[1]['name']).to eq(CloudProvider.last.name)
     end
-
   end
 
-  describe "GET /cloud_providers?fqdn=" do
+  describe "GET /cloud_providers/{name}" do
+    it "should return a cloud provider" do
+      api_get(action: "cloud_providers/#{CloudProvider.last.name}", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+      
+      cp = JSON.parse(response.body)
+      expect(cp["name"]).to eq(CloudProvider.last.name)
+    end
+
+    it "should return a cloud provider and set X-Idb-Api-Token header of token usable for updating" do
+      user = FactoryGirl.create(:user)
+      owner_1 = FactoryGirl.create(:owner, users: [user])
+      owner_2 = FactoryGirl.create(:owner, users: [user])
+      token_1 = FactoryGirl.create :api_token_rw, owner: owner_1, name: "FOOBARTOKEN1"
+      token_2 = FactoryGirl.create :api_token_r, owner: owner_2, name: "FOOBARTOKEN2"
+      allow(User).to receive(:current).and_return(owner_1.users.first)
+      allow(User).to receive(:current).and_return(owner_2.users.first)
+
+      c1 = FactoryGirl.create(:cloud_provider, owner: owner_1)   
+
+      get "/api/v3/cloud_providers/#{c1.name}", headers: {'X-IDB-API-Token': "#{token_1.token}, #{token_2.token}" }
+      expect(response.status).to eq(200)
+
+      expect(response.header["X-Idb-Api-Token"]).to eq(token_1.token)
+
+      cp = JSON.parse(response.body)
+      expect(cp["name"]).to eq(c1.name)
+    end
+  end
+
+  describe "GET /cloud_providers?name=" do
     it 'should filter cloud provider items for items with this name' do
       api_get(action: "cloud_providers?name=#{CloudProvider.last.name}", token: @api_token_r, version: "3")
       expect(response.status).to eq(200)

--- a/spec/api/v3/cloud_provider_api_spec.rb
+++ b/spec/api/v3/cloud_provider_api_spec.rb
@@ -55,17 +55,6 @@ describe 'Cloud Provider API V3' do
     end
   end
 
-  describe "GET /cloud_providers with header authorization" do
-    it 'should return all cloud provider configurations' do
-      api_get_auth_header(action: "cloud_providers", token: @api_token_r, version: "3")
-      expect(response.status).to eq(200)
-
-      cloud_providers = JSON.parse(response.body)
-      expect(cloud_providers.size).to eq(1)
-      expect(cloud_providers[0]['name']).to eq(CloudProvider.last.name)
-    end
-  end
-
   describe "GET /cloud_providers?fqdn=" do
     it 'should filter cloud provider items for items with this name' do
       api_get(action: "cloud_providers?name=#{CloudProvider.last.name}", token: @api_token_r, version: "3")

--- a/spec/api/v3/inventories_api_spec.rb
+++ b/spec/api/v3/inventories_api_spec.rb
@@ -53,6 +53,27 @@ describe 'Inventories API V3' do
       expect(inventories.size).to eq(1)
       expect(inventories[0]['inventory_number']).to eq(Inventory.last.inventory_number)
     end
+
+    it "returns inventories for all owners for multiple tokens" do
+      user = FactoryGirl.create(:user)
+      owner_1 = FactoryGirl.create(:owner, users: [user])
+      owner_2 = FactoryGirl.create(:owner, users: [user])
+      token_1 = FactoryGirl.create :api_token_r, owner: owner_1, name: "FOOBARTOKEN1"
+      token_2 = FactoryGirl.create :api_token_r, owner: owner_2, name: "FOOBARTOKEN2"
+      allow(User).to receive(:current).and_return(owner_1.users.first)
+      allow(User).to receive(:current).and_return(owner_2.users.first)
+
+      i1 = FactoryGirl.create(:inventory, inventory_number: "abcdef", owner: owner_1)
+      i2 = FactoryGirl.create(:inventory, inventory_number: "ghijkl", owner: owner_2)
+
+      get "/api/v3/inventories", headers: {'X-IDB-API-Token': "#{token_1.token}, #{token_2.token}" }
+      expect(response.status).to eq(200)
+
+      inventories = JSON.parse(response.body)
+      expect(inventories.size).to eq(2)
+      expect(inventories[0]['inventory_number']).to eq(Inventory.first.inventory_number)
+      expect(inventories[1]['inventory_number']).to eq(Inventory.last.inventory_number)
+    end
   end
 
   describe "GET /inventory?inventory_number=" do

--- a/spec/api/v3/inventories_api_spec.rb
+++ b/spec/api/v3/inventories_api_spec.rb
@@ -76,7 +76,29 @@ describe 'Inventories API V3' do
     end
   end
 
-  describe "GET /inventory?inventory_number=" do
+  describe "GET /inventories/{inventory_number}" do
+    it "should return an inventory item and set X-Idb-Api-Token header to token usable for updating" do
+      user = FactoryGirl.create(:user)
+      owner_1 = FactoryGirl.create(:owner, users: [user])
+      owner_2 = FactoryGirl.create(:owner, users: [user])
+      token_1 = FactoryGirl.create :api_token_rw, owner: owner_1, name: "FOOBARTOKEN1"
+      token_2 = FactoryGirl.create :api_token_r, owner: owner_2, name: "FOOBARTOKEN2"
+      allow(User).to receive(:current).and_return(owner_1.users.first)
+      allow(User).to receive(:current).and_return(owner_2.users.first)
+
+      inv = FactoryGirl.create(:inventory, owner: owner_1)   
+
+      get "/api/v3/inventories/#{inv.inventory_number}", headers: {'X-IDB-API-Token': "#{token_1.token}, #{token_2.token}" }
+      expect(response.status).to eq(200)
+
+      expect(response.header["X-Idb-Api-Token"]).to eq(token_1.token)
+
+      json_inv = JSON.parse(response.body)
+      expect(json_inv["inventory_number"]).to eq(inv.inventory_number)
+    end
+  end
+
+  describe "GET /inventories?inventory_number=" do
     it 'should filter inventory items for items with this inventory_number' do
       api_get(action: "inventories?inventory_number=#{Inventory.last.inventory_number}", token: @api_token_r, version: "3")
       expect(response.status).to eq(200)

--- a/spec/api/v3/inventories_api_spec.rb
+++ b/spec/api/v3/inventories_api_spec.rb
@@ -55,17 +55,6 @@ describe 'Inventories API V3' do
     end
   end
 
-  describe "GET /inventories with header authorization" do
-    it 'should return all inventories' do
-      api_get_auth_header(action: "inventories", token: @api_token_r, version: "3")
-      expect(response.status).to eq(200)
-
-      inventories = JSON.parse(response.body)
-      expect(inventories.size).to eq(1)
-      expect(inventories[0]['inventory_number']).to eq(Inventory.last.inventory_number)
-    end
-  end
-
   describe "GET /inventory?inventory_number=" do
     it 'should filter inventory items for items with this inventory_number' do
       api_get(action: "inventories?inventory_number=#{Inventory.last.inventory_number}", token: @api_token_r, version: "3")

--- a/spec/api/v3/locations_api_spec.rb
+++ b/spec/api/v3/locations_api_spec.rb
@@ -46,7 +46,7 @@ describe 'Location API V3' do
 
   describe "GET /locations" do
     it 'should return all locations' do
-      api_get_auth_header(action: "locations", token: @api_token_r, version: "3")
+      api_get(action: "locations", token: @api_token_r, version: "3")
       expect(response.status).to eq(200)
 
       locations = JSON.parse(response.body)

--- a/spec/api/v3/locations_api_spec.rb
+++ b/spec/api/v3/locations_api_spec.rb
@@ -141,7 +141,7 @@ describe 'Location API V3' do
       payload = {
         "name":"foobar"
       }
-      api_post_json(action: "locations", token: @api_token, payload: payload, version: "3")
+      api_post_json(action: "locations/roots", token: @api_token, payload: payload, version: "3")
       expect(response.status).to eq(401)
     end
   end

--- a/spec/api/v3/locations_api_spec.rb
+++ b/spec/api/v3/locations_api_spec.rb
@@ -53,6 +53,27 @@ describe 'Location API V3' do
       expect(locations.size).to eq(1)
       expect(locations[0]['name']).to eq(Location.last.name)
     end
+
+    it 'should return all locations for multiple owners' do
+      user = FactoryGirl.create(:user)
+      owner_1 = FactoryGirl.create(:owner, users: [user])
+      owner_2 = FactoryGirl.create(:owner, users: [user])
+      token_1 = FactoryGirl.create :api_token_r, owner: owner_1, name: "FOOBARTOKEN1"
+      token_2 = FactoryGirl.create :api_token_r, owner: owner_2, name: "FOOBARTOKEN2"
+      allow(User).to receive(:current).and_return(owner_1.users.first)
+      allow(User).to receive(:current).and_return(owner_2.users.first)
+
+      FactoryGirl.create :location, owner: owner_1
+      FactoryGirl.create :location, owner: owner_2
+
+      get "/api/v3/locations", headers: {'X-IDB-API-Token': "#{token_1.token}, #{token_2.token}" }
+      expect(response.status).to eq(200)
+
+      locations = JSON.parse(response.body)
+      expect(locations.size).to eq(2)
+      expect(locations[0]['name']).to eq(Location.first.name)
+      expect(locations[1]['name']).to eq(Location.second.name)
+    end
   end
 
   describe "GET /locations?name=" do

--- a/spec/api/v3/machines_api_spec.rb
+++ b/spec/api/v3/machines_api_spec.rb
@@ -18,7 +18,7 @@ describe 'Machines API V3' do
     @api_token = FactoryGirl.build :api_token, owner: @owner
     @api_token_r = FactoryGirl.create :api_token_r, owner: @owner
     @api_token_w = FactoryGirl.create :api_token_w, owner: @owner
-
+    @api_token_rw = FactoryGirl.create :api_token_rw, owner: @owner
 
     # prevent execution of VersionChangeWorker, depends on running sidekiq workers
     allow(VersionChangeWorker).to receive(:perform_async) do |arg|
@@ -150,6 +150,15 @@ describe 'Machines API V3' do
 
       machine = JSON.parse(response.body)
       expect(machine).to eq({"response_type" => "error", "response" => "Not Found"})
+    end
+
+    it 'should return the token usable for updating this machine' do
+      api_get(action: "machines/#{Machine.last.fqdn}", token: @api_token_rw, version: "3")
+      expect(response.status).to eq(200)
+
+      machine = JSON.parse(response.body)
+      expect(machine['fqdn']).to eq(Machine.last.fqdn)
+      expect(response.headers["X-Idb-Api-Token"]).to eq(@api_token_rw.token)
     end
   end
 

--- a/spec/api/v3/machines_api_spec.rb
+++ b/spec/api/v3/machines_api_spec.rb
@@ -68,16 +68,26 @@ describe 'Machines API V3' do
       # expect just the machine added in before block
       expect(machines.size).to eq(1)
     end
-  end
 
-  describe "GET /machines with header authorization" do
-    it 'should return all machines' do
-      api_get_auth_header(action: "machines", token: @api_token_r, version: "3")
+    it "returns machines for all owners for multiple tokens" do
+      user = FactoryGirl.create(:user)
+      owner_1 = FactoryGirl.create(:owner, users: [user])
+      owner_2 = FactoryGirl.create(:owner, users: [user])
+      token_1 = FactoryGirl.create :api_token_r, owner: owner_1, name: "FOOBARTOKEN1"
+      token_2 = FactoryGirl.create :api_token_r, owner: owner_2, name: "FOOBARTOKEN2"
+      allow(User).to receive(:current).and_return(owner_1.users.first)
+      allow(User).to receive(:current).and_return(owner_2.users.first)
+
+      m1 = FactoryGirl.create(:machine, fqdn: "foobar.example.org", owner: owner_1)
+      m2 = FactoryGirl.create(:machine, fqdn: "bazbar.example.org", owner: owner_2)
+
+      get "/api/v3/machines", headers: {'X-IDB-API-Token': "#{token_1.token}, #{token_2.token}" }
       expect(response.status).to eq(200)
 
       machines = JSON.parse(response.body)
-      expect(machines.size).to eq(1)
-      expect(machines[0]['fqdn']).to eq(Machine.last.fqdn)
+      expect(machines.size).to eq(2)
+      expect(machines[0]['fqdn']).to eq(Machine.first.fqdn)
+      expect(machines[1]['fqdn']).to eq(Machine.last.fqdn)
     end
   end
 
@@ -97,6 +107,24 @@ describe 'Machines API V3' do
 
       machines = JSON.parse(response.body)
       expect(machines).to eq({"response_type" => "error", "response" => "Not Found"})
+    end
+  end
+
+  describe "GET /machines/{fqdn}" do
+    it 'should return the corresponding machine' do
+      api_get(action: "machines/#{Machine.last.fqdn}", token: @api_token_r, version: "3")
+      expect(response.status).to eq(200)
+
+      machine = JSON.parse(response.body)
+      expect(machine['fqdn']).to eq(Machine.last.fqdn)
+    end
+
+    it 'should return empty JSON and code 404 if machine not found' do
+      api_get(action: "machines/does.not.exist", token: @api_token_r, version: "3")
+      expect(response.status).to eq(404)
+
+      machine = JSON.parse(response.body)
+      expect(machine).to eq({"response_type" => "error", "response" => "Not Found"})
     end
   end
 
@@ -440,8 +468,8 @@ describe 'Machines API V3' do
       }
       api_post_json(action: "machines", token: @api_token_w, payload: payload, version: "3")
       raw = Machine.last.raw_data_api
-      expect(JSON.parse(raw)[@api_token_w.token]).to be
-      expect(JSON.parse(raw)[@api_token_w.token]["fqdn"]).to eq("foobar.example.com")
+      expect(JSON.parse(raw)[@api_token_w.name]).to be
+      expect(JSON.parse(raw)[@api_token_w.name]["fqdn"]).to eq("foobar.example.com")
     end
   end
 
@@ -455,9 +483,13 @@ describe 'Machines API V3' do
       }
       api_put_json(action: "machines/#{m.fqdn}", token: @api_token_w, payload: payload, version: "3")
       raw = Machine.last.raw_data_api
-      expect(JSON.parse(raw)[@api_token_w.token]).to be
-      expect(JSON.parse(raw)[@api_token_w.token]["cores"]).to eq(8)
+      expect(JSON.parse(raw)[@api_token_w.name]).to be
+      expect(JSON.parse(raw)[@api_token_w.name]["cores"]).to eq(8)
     end
-  end      
+  end
+  
+  describe "GET machines" do
+
+  end
 end
 

--- a/spec/api/v3/nics_api_spec.rb
+++ b/spec/api/v3/nics_api_spec.rb
@@ -33,6 +33,29 @@ describe 'Nics API V3' do
     end
   end
 
+  describe "GET /nics/{id}" do
+    it "should return a nic and set X-Idb-Api-Token header to token usable for updating" do
+      user = FactoryGirl.create(:user)
+      owner_1 = FactoryGirl.create(:owner, users: [user])
+      owner_2 = FactoryGirl.create(:owner, users: [user])
+      token_1 = FactoryGirl.create :api_token_rw, owner: owner_1, name: "FOOBARTOKEN1"
+      token_2 = FactoryGirl.create :api_token_r, owner: owner_2, name: "FOOBARTOKEN2"
+      allow(User).to receive(:current).and_return(owner_1.users.first)
+      allow(User).to receive(:current).and_return(owner_2.users.first)
+
+      m = FactoryGirl.create :machine, owner: owner_1
+      n = FactoryGirl.create :nic, machine: m 
+
+      get "/api/v3/nics/#{n.id}", headers: {'X-IDB-API-Token': "#{token_1.token}, #{token_2.token}" }
+      expect(response.status).to eq(200)
+
+      expect(response.header["X-Idb-Api-Token"]).to eq(token_1.token)
+
+      json_n = JSON.parse(response.body)
+      expect(json_n["id"]).to eq(n.id)
+    end
+  end
+
   describe "GET /nics" do
     it 'should return all nics' do
       wrong_owner = FactoryGirl.create :owner

--- a/spec/api/v3/switches_api_spec.rb
+++ b/spec/api/v3/switches_api_spec.rb
@@ -156,7 +156,6 @@ describe 'Switches API V3' do
       FactoryGirl.create(:switch_port, switch: s, nic: FactoryGirl.create(:nic), number: 2)
 
       api_get(action: "switches/#{s.fqdn}/ports", token: @api_token_r, version: "3")
-      puts "IN SPEC", response.body
       expect(response.status).to eq(200)
       switch_ports = JSON.parse(response.body)
       expect(switch_ports.size).to eq(2)
@@ -195,7 +194,6 @@ describe 'Switches API V3' do
         "number":1,"nic": n2.name, "machine": m.fqdn
       }
       api_put_json(action: "switches/switch.example.org/ports/1", token: @api_token_w, version: 3, payload: payload)
-      puts response.body
       expect(response.status).to eq(201)
       switch_port = JSON.parse(response.body)
       expect(switch_port["number"]).to eq(1)

--- a/spec/api/v3/switches_api_spec.rb
+++ b/spec/api/v3/switches_api_spec.rb
@@ -55,17 +55,6 @@ describe 'Switches API V3' do
     end
   end
 
-  describe "GET /switches with header authorization" do
-    it 'should return all switches' do
-      api_get_auth_header(action: "switches", token: @api_token_r, version: "3")
-      expect(response.status).to eq(200)
-
-      switches = JSON.parse(response.body)
-      expect(switches.size).to eq(1)
-      expect(switches[0]['fqdn']).to eq(Switch.last.fqdn)
-    end
-  end
-
   describe "GET /switch?fqdn=" do
     it 'should filter switch items for items with this fqdn' do
       api_get(action: "switches?fqdn=#{Switch.last.fqdn}", token: @api_token_r, version: "3")

--- a/spec/api_helper.rb
+++ b/spec/api_helper.rb
@@ -1,10 +1,10 @@
-def api_get(action:, token:, params: {}, version: "2")
+def api_get_auth_params(action:, token:, params: {}, version: "2")
   params.merge!({"idb_api_token": token.token })
   get "/api/v#{version}/#{action}", params: params
   JSON.parse(response.body) rescue {}
 end
 
-def api_get_auth_header(action: , token: , params: {}, version: "2")
+def api_get(action: , token: , params: {}, version: "2")
   get "/api/v#{version}/#{action}", params: params, headers: {'X-IDB-API-Token': token.token }
   JSON.parse(response.body) rescue {}
 end

--- a/spec/factories/api_tokens.rb
+++ b/spec/factories/api_tokens.rb
@@ -19,4 +19,11 @@ FactoryGirl.define do
     read false
     write true
   end	
+
+  factory :api_token_rw, class: ApiToken do
+    sequence(:token) { |n| "rw-token-#{n}" }
+    sequence(:name) { |n| "rw-token-name-#{n}" }
+    read true
+    write true
+  end	
 end


### PR DESCRIPTION
this adds the capability to use multiple tokens in reading requests for api v3.

```
$ curl -v -H "X-Idb-Api-Token: token1" -H "X-Idb-Api-Token: token2" http://idb.example.org/api/v3/machines
...
> X-Idb-Api-Token: token1
> X-Idb-Api-Token: token2
...
```
for requests which only return one object, the first token which can be used for updating (write access) this item is returned, again as `X-Idb-Api-Token`-header:
```
$ curl -v -H "X-Idb-Api-Token: token1" -H "X-Idb-Api-Token: token2" http://idb.example.org/api/v3/machines/test.example.org
...
> X-Idb-Api-Token: token1
> X-Idb-Api-Token: token2
...
< X-Idb-Api-Token: token2
```
this enables api clients to update objects of different owners by
1. requesting the object to be updated with all tokens they know
2. performing the actual update using the token returned via header