### PR TITLE
enhancements for maintenance announcements

### DIFF
--- a/app/models/maintenance_ticket.rb
+++ b/app/models/maintenance_ticket.rb
@@ -29,6 +29,17 @@ class MaintenanceTicket < ApplicationRecord
   def format_params
     a = maintenance_announcement
     t = a.maintenance_template
-    {begin_date: a.begin_date.to_formatted_s(:db), end_date: a.end_date.to_formatted_s(:db), reason: a.reason, impact: a.impact, machines: format_machines_fqdns, user: a.user.display_name }
+    { 
+      begin_date: a.begin_date.to_formatted_s(:announcement_date),
+      end_date: a.end_date.to_formatted_s(:announcement_date),
+      begin_time: a.begin_date.to_formatted_s(:announcement_time),
+      end_time: a.end_date.to_formatted_s(:announcement_time),
+      begin_full: a.begin_date.to_formatted_s(:announcement_full),
+      end_full: a.end_date.to_formatted_s(:announcement_full),
+      reason: a.reason,
+      impact: a.impact,
+      machines: format_machines_fqdns,
+      user: a.user.display_name 
+    }
   end
 end

--- a/app/services/ticket_service.rb
+++ b/app/services/ticket_service.rb
@@ -4,23 +4,29 @@ class TicketService
         subject = ticket.format_subject
         queue = IDB.config.rt.queue
         requestor = IDB.config.rt.requestor
-        cc = [ ticket.owner.announcement_contact ]
-        ticket_id = TicketService.create_rt_ticket(queue, requestor, cc, subject, text)
+
+        # create ticket
+        ticket_id = TicketService.create_rt_ticket(queue, requestor, subject, text)
         ticket.ticket_id = ticket_id
+
+        # comment ticket to send announcement to real contact in cc
+        cc = [ ticket.owner.announcement_contact ]
+        TicketService.reply_rt_ticket(ticket_id, cc, subject, text)
+
         ticket.save!
     end
 
     private
 
-    def self.create_rt_ticket(queue, requestor, cc, subject, text)
-        uri = self.build_uri
+    def self.create_rt_ticket(queue, requestor, subject, text)
+        uri = self.build_create_uri
         
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = uri.scheme == 'https'
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         http.read_timeout = 5
 
-        req = self.build_request(uri, queue, requestor, cc, subject, text)
+        req = self.build_create_request(uri, queue, requestor, subject, text)
        
         res = http.request(req)
         
@@ -36,38 +42,68 @@ class TicketService
         return ticket_id
     end
 
-    def self.encode_rt_ticket(queue, requestor, cc, subject, text)
+    def self.encode_create_ticket(queue, requestor, subject, text)
         text = self.indent(text)
 
         x = %q(id: new
 Queue: %{queue}
 Requestor: %{requestor}
 Subject: %{subject}
-Cc: %{cc}
 Text: %{text}
 )
-        x % {queue: queue, requestor: requestor, cc: cc.join(","), subject: subject, text: text }
+        x % {queue: queue, requestor: requestor, subject: subject, text: text }
     end
 
-    # RT wants every line except for the first one to be indented with one space
-    def self.indent(text)
-        lines = text.split("\n")
-        lines_new = [lines[0]]
-        lines[1..-1].each do |line|
-            lines_new << " #{line}"
-        end
-        lines_new.join("\n")
-    end
-
-    def self.build_uri
+    def self.build_create_uri
         uri = URI(IDB.config.rt.create_ticket_url)
         uri.query = URI.encode_www_form({user: IDB.config.rt.user, pass: IDB.config.rt.password })
         uri
     end
 
-    def self.build_request(uri, queue, requestor, cc, subject, text)
+    def self.build_create_request(uri, queue, requestor, subject, text)
         req = Net::HTTP::Post.new(uri.request_uri)
-        req.body = URI.encode_www_form({content: TicketService.encode_rt_ticket(queue, requestor, cc, subject, text)})
+        req.body = URI.encode_www_form({content: TicketService.encode_create_ticket(queue, requestor, subject, text)})
+        req
+    end
+
+    def self.reply_rt_ticket(ticket_id, cc, subject, text)
+        uri = self.build_reply_uri(ticket_id)
+        
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == 'https'
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.read_timeout = 5
+
+        req = self.build_reply_request(uri, ticket_id, cc, subject, text)
+
+        res = http.request(req)
+        
+        if res.code != "200" 
+            return nil
+        end
+    end
+
+    def self.encode_reply_ticket(ticket_id, cc, subject, text)
+        text = self.indent(text)
+
+        x = %q(id: %{ticket_id}
+Action: correspond
+Cc: %{cc}
+Subject: %{subject}
+Text: %{text}
+)
+        x % {ticket_id: ticket_id, cc: cc.join(","), subject: subject, text: text }
+    end
+
+    def self.build_reply_uri(ticket_id)
+        uri = URI(IDB.config.rt.reply_ticket_url % ticket_id)
+        uri.query = URI.encode_www_form({user: IDB.config.rt.user, pass: IDB.config.rt.password })
+        uri
+    end
+
+    def self.build_reply_request(uri, ticket_id, cc, subject, text)
+        req = Net::HTTP::Post.new(uri.request_uri)
+        req.body = URI.encode_www_form({content: TicketService.encode_reply_ticket(ticket_id, cc, subject, text)})
         req
     end
 
@@ -79,5 +115,15 @@ Text: %{text}
         end
 
         m[1].to_i
+    end
+
+    # RT wants every line except for the first one to be indented with one space
+    def self.indent(text)
+        lines = text.split("\n")
+        lines_new = [lines[0]]
+        lines[1..-1].each do |line|
+            lines_new << " #{line}"
+        end
+        lines_new.join("\n")
     end
 end

--- a/app/views/maintenance_templates/_form.html.erb
+++ b/app/views/maintenance_templates/_form.html.erb
@@ -13,8 +13,12 @@
             <ul>
                 <li><code>%{user}</code> - Display name of user sending announcement(e.g. <%= @current_user.display_name %>)</li>
                 <li><code>%{machines}</code> - FQDNs of affected machines</li>
-                <li><code>%{begin_date}</code> - Begin date and time of maintenance</li>
-                <li><code>%{end_date}</code> - End date and time of maintenance</li>
+                <li><code>%{begin_date}</code> - Begin date maintenance</li>
+                <li><code>%{end_date}</code> - End date of maintenance</li>
+                <li><code>%{begin_time}</code> - Begin time of maintenance</li>
+                <li><code>%{end_time}</code> - End time of maintenance</li>
+                <li><code>%{begin_full}</code> - Begin date and time of maintenance</li>
+                <li><code>%{end_full}</code> - End date and time of maintenance</li>
                 <li><code>%{reason}</code> - Maintenance reason</li>
                 <li><code>%{impact}</code> - Maintenance impact</li>
             </ul>

--- a/config-example/application.yml
+++ b/config-example/application.yml
@@ -70,9 +70,10 @@ defaults: &defaults
   rt:
     ticket_url: 'https://rt.example.com/Ticket/Display.html?id=%s'
     create_ticket_url: 'https://rt.example.com/REST/1.0/ticket/new'
+    reply_ticket_url: 'https://rt.example.com/REST/1.0/ticket/%s/comment'
     user: 'rt-api-user'
     password: 'rt-api-user-password'
-    requestor: 'rt-requestor-mail'
+    requestor: 'requestor mail address OR empty string if no create mail should be send'
     queue: 'RT-Queue-Name'
   mrtg:
     base_url: 'https://mrtg.example.com/'

--- a/config-example/initializers/time_format.rb
+++ b/config-example/initializers/time_format.rb
@@ -1,0 +1,3 @@
+Time::DATE_FORMATS[:announcement_date] = '%d.%m.%Y'
+Time::DATE_FORMATS[:announcement_time] = '%H:%M'
+Time::DATE_FORMATS[:announcement_full] = '%d.%m.%Y %H:%M'

--- a/spec/services/ticket_service_spec.rb
+++ b/spec/services/ticket_service_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe TicketService do
-  describe 'encode_rt_ticket' do
-    it 'encodes data to be usable as content in a RT API request' do
+  describe 'encode_create_ticket' do
+    it 'encodes data to be usable as content in a RT API create request' do
       queue = "Queue"
       requestor = "Requestor"
       subject = "Subject"
-      cc = ["test@example.com"]
       text = %q(multi
 line
 string)
@@ -15,12 +14,36 @@ string)
  line
  string)
 
-      x = TicketService.encode_rt_ticket(queue, requestor, cc, subject, text)
+      x = TicketService.encode_create_ticket(queue, requestor, subject, text)
       want = %Q(id: new
 Queue: #{queue}
 Requestor: #{requestor}
 Subject: #{subject}
+Text: #{want_text}
+)
+
+      expect(x).to eq(want)
+    end
+  end
+
+  describe 'encode_reply_ticket' do
+    it 'encodes data to be usable as content in a RT API reply request' do
+      ticket_id = 1234
+      cc = [ "cc" ]
+      subject = "Subject"
+      text = %q(multi
+line
+string)
+
+      want_text = %q(multi
+ line
+ string)
+
+      x = TicketService.encode_reply_ticket(ticket_id, cc, subject, text)
+      want = %Q(id: #{ticket_id}
+Action: correspond
 Cc: #{cc.join(",")}
+Subject: #{subject}
 Text: #{want_text}
 )
 
@@ -54,19 +77,33 @@ string)
     end
   end
 
-  describe 'build_uri' do
+  describe 'build_create_uri' do
     it 'builds the request uri to create a new ticket' do
       IDB.config.rt.create_ticket_url = "http://support.example.com"
       IDB.config.rt.user = "user"
       IDB.config.rt.password = "password"
 
-      uri = TicketService.build_uri
+      uri = TicketService.build_create_uri
 
       expect(uri.to_s).to eq("#{IDB.config.rt.create_ticket_url}?user=#{IDB.config.rt.user}&pass=#{IDB.config.rt.password}")
     end
   end
 
-  describe 'build_request' do
+  describe 'build_reply_uri' do
+    it 'builds the request uri to reply a ticket' do
+      IDB.config.rt.reply_ticket_url = "http://support.example.com"
+      IDB.config.rt.user = "user"
+      IDB.config.rt.password = "password"
+
+      ticket_id = 1234
+
+      uri = TicketService.build_reply_uri(ticket_id)
+
+      expect(uri.to_s).to eq("#{IDB.config.rt.reply_ticket_url % ticket_id}?user=#{IDB.config.rt.user}&pass=#{IDB.config.rt.password}")
+    end
+  end
+
+  describe 'build_create_request' do
     it 'builds a request to create a new ticket' do
       IDB.config.rt.create_ticket_url = "http://support.example.com"
       IDB.config.rt.user = "user"
@@ -75,7 +112,6 @@ string)
       queue = "Queue"
       requestor = "Requestor"
       subject = "Subject"
-      cc = ["test@example.com"]
       text = %q(multi
 line
 string
@@ -90,10 +126,43 @@ string
 Queue: #{queue}
 Requestor: #{requestor}
 Subject: #{subject}
-Cc: #{cc[0]}
 Text: #{want_text})
       
-      req = TicketService.build_request(TicketService.build_uri, queue, requestor, cc, subject, text)
+      req = TicketService.build_create_request(TicketService.build_create_uri, queue, requestor, subject, text)
+
+      dec = URI.decode_www_form(req.body)
+
+      expect(dec[0][0]).to eq("content")
+      expect(dec[0][1]).to eq(want)
+    end
+  end
+
+  describe 'build_reply_request' do
+    it 'builds a request to create a new ticket' do
+      IDB.config.rt.reply_ticket_url = "http://support.example.com"
+      IDB.config.rt.user = "user"
+      IDB.config.rt.password = "password"
+
+      ticket_id = 1234
+      cc = [ "cc" ]
+      subject = "Subject"
+      text = %q(multi
+line
+string
+)
+
+      want_text = %q(multi
+ line
+ string
+)      
+
+      want = %Q(id: #{ticket_id}
+Action: correspond
+Cc: #{cc.join(",")}
+Subject: #{subject}
+Text: #{want_text})
+      
+      req = TicketService.build_reply_request(TicketService.build_reply_uri(ticket_id), ticket_id, cc, subject, text)
 
       dec = URI.decode_www_form(req.body)
 


### PR DESCRIPTION
- change date formatting in announcements to dd.mm.yyyy for now, add placeholders to just use
the date, time or both.

- to have the announcement sent to the machines owner, first create a
rt ticket, then add a reply with the machines owner contact address
as cc.
the reason for this is that without additional configuration in rt, created
tickets aren't send to the cc, and using the contact address as
requestor while creating adds the usual "we've received your message" preamble,
which we don't want in this case.