### PR TITLE
Add option to send announcements to a single mail address

### DIFF
--- a/app/controllers/maintenance_announcements_controller.rb
+++ b/app/controllers/maintenance_announcements_controller.rb
@@ -164,7 +164,7 @@ class MaintenanceAnnouncementsController < ApplicationController
         tickets = []
 
         # if a email override is used, only create one ticket
-        if announcement.email != ""
+        if announcement.email
             tickets << MaintenanceTicket.new(maintenance_announcement: announcement, machines: machines)
             return tickets
         end

--- a/app/models/maintenance_ticket.rb
+++ b/app/models/maintenance_ticket.rb
@@ -30,7 +30,7 @@ class MaintenanceTicket < ApplicationRecord
       return maintenance_announcement.email
     end
 
-    return ticket.owner.announcement_contact
+    return owner.announcement_contact
   end
 
   private
@@ -51,8 +51,8 @@ class MaintenanceTicket < ApplicationRecord
       user: a.user.display_name 
     }
 
-    # don't show machines in formatted ticket
-    if email
+    # don't show machines in formatted ticket if we send to one address
+    if maintenance_announcement.email
       p[:machines] = ""
     end
     

--- a/app/models/maintenance_ticket.rb
+++ b/app/models/maintenance_ticket.rb
@@ -24,12 +24,21 @@ class MaintenanceTicket < ApplicationRecord
     owners.group(:id).first
   end
 
+  # get the email address, either the owners or the one set in the announcement
+  def email
+    if maintenance_announcement.email
+      return maintenance_announcement.email
+    end
+
+    return ticket.owner.announcement_contact
+  end
+
   private
 
   def format_params
     a = maintenance_announcement
     t = a.maintenance_template
-    { 
+    p = { 
       begin_date: a.begin_date.to_formatted_s(:announcement_date),
       end_date: a.end_date.to_formatted_s(:announcement_date),
       begin_time: a.begin_date.to_formatted_s(:announcement_time),
@@ -41,5 +50,12 @@ class MaintenanceTicket < ApplicationRecord
       machines: format_machines_fqdns,
       user: a.user.display_name 
     }
+
+    # don't show machines in formatted ticket
+    if email
+      p[:machines] = ""
+    end
+    
+    p
   end
 end

--- a/app/presenters/maintenance_announcement_presenter.rb
+++ b/app/presenters/maintenance_announcement_presenter.rb
@@ -1,7 +1,7 @@
 class MaintenanceAnnouncementPresenter < Keynote::Presenter
     presents :maintenance_announcement
 
-    delegate :id, :user, :reason, :impact, to: :maintenance_announcement
+    delegate :id, :user, :reason, :impact, :email, to: :maintenance_announcement
 
     def ticket_links
         links = Array.new

--- a/app/services/ticket_service.rb
+++ b/app/services/ticket_service.rb
@@ -10,7 +10,7 @@ class TicketService
         ticket.ticket_id = ticket_id
 
         # comment ticket to send announcement to real contact in cc
-        cc = [ ticket.owner.announcement_contact ]
+        cc = [ ticket.email ]
         TicketService.reply_rt_ticket(ticket_id, cc, subject, text)
 
         ticket.save!

--- a/app/views/maintenance_announcements/_table.html.erb
+++ b/app/views/maintenance_announcements/_table.html.erb
@@ -9,7 +9,7 @@
       <th>Reason</th>
       <th>Impact</th>
       <th>Machines</th>
-      <th>Owners</th>
+      <th>Recipients</th>
       <th>Tickets</th>
     </tr>
   </thead>
@@ -25,7 +25,13 @@
         <td><%= truncate maintenance_announcement.reason, length: 20 %></td>
         <td><%= truncate maintenance_announcement.impact, length: 20 %></td>
         <td><%= maintenance_announcement.machine_links %></td>
-        <td><%= maintenance_announcement.owner_links %></td>
+        <td>
+        <%- if maintenance_announcement.email -%>
+        <%= maintenance_announcement.email %>
+        <%- else -%>
+        <%= maintenance_announcement.owner_links %>
+        <%- end -%>
+        </td>
         <td><%= maintenance_announcement.ticket_links %></td>
       </tr>
     <%- end -%>

--- a/app/views/maintenance_announcements/new.html.erb
+++ b/app/views/maintenance_announcements/new.html.erb
@@ -51,6 +51,16 @@ have a wizard style dialog done on the client side #%>
             </ul>
           </div>
         <%- end %>
+        <%- if @maintenance_templates.empty? -%>
+          <div class="alert">
+            <strong>No announcement templates defined, please create one!</strong>
+          </div>
+        <%- end -%>
+        <%- if @no_maintenance_template -%>
+          <div class="alert">
+            <strong>Announcement template not found!</strong>
+          </div>
+        <%- end -%>
         <%= render 'machines_table' %>
         <label for="ignore_vms">
         <%= check_box_tag("ignore_vms") %> Ignore unselected VMs
@@ -73,7 +83,8 @@ have a wizard style dialog done on the client side #%>
         </div>
         <div class="span6">
           <%= label_tag(:email, "E-Mail Address") %>
-          <%= email_field_tag(:email) %>
+          <%= autocomplete_field_tag(:email, '', autocomplete_maintenance_announcement_email_maintenance_announcements_path) %>
+          <%#= email_field_tag(:email, :url => "foobar", :as => :autocomplete) #%>
 
           <%= label_tag(:begin_date, "Begin") %>
           <%= datetime_select(:maintenance_announcement, :begin_date, default: {minute: 0 } ) %>

--- a/app/views/maintenance_announcements/new.html.erb
+++ b/app/views/maintenance_announcements/new.html.erb
@@ -72,6 +72,9 @@ have a wizard style dialog done on the client side #%>
           <%= text_area_tag(:impact, params[:impact], class: "span12", rows: "15") %>
         </div>
         <div class="span6">
+          <%= label_tag(:email, "E-Mail Address") %>
+          <%= email_field_tag(:email) %>
+
           <%= label_tag(:begin_date, "Begin") %>
           <%= datetime_select(:maintenance_announcement, :begin_date, default: {minute: 0 } ) %>
 

--- a/config-example/routes.rb
+++ b/config-example/routes.rb
@@ -51,7 +51,9 @@ InfrastructureDb::Application.routes.draw do
   resources :softwares, only: [:index]
   resources :cloud_providers
   resources :users, only: [:index, :edit, :update]
-  resources :maintenance_announcements
+  resources :maintenance_announcements do
+    get :autocomplete_maintenance_announcement_email, :on => :collection
+  end
   resources :maintenance_templates
 
   post 'markup/render', to: 'markup#do_render'

--- a/db/migrate/20180831154056_add_email_to_maintenance_announcements.rb
+++ b/db/migrate/20180831154056_add_email_to_maintenance_announcements.rb
@@ -1,0 +1,5 @@
+class AddEmailToMaintenanceAnnouncements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :maintenance_announcements, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323105933) do
+ActiveRecord::Schema.define(version: 20180831154056) do
 
   create_table "api_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "token"
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 20180323105933) do
     t.datetime "updated_at",                            null: false
     t.datetime "end_date"
     t.integer  "user_id"
+    t.string   "email"
     t.index ["maintenance_template_id"], name: "index_maintenance_announcements_on_maintenance_template_id", using: :btree
     t.index ["user_id"], name: "index_maintenance_announcements_on_user_id", using: :btree
   end

--- a/spec/controllers/maintenance_announcements_controller_spec.rb
+++ b/spec/controllers/maintenance_announcements_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement affecting a single owner" do
-            post :create, params: { maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id, @m1.id ] }
+            post :create, params: { maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @m1.id ] }
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.end_date <=> @end_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
@@ -48,7 +48,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
 
         it "creates a new maintenance announcement affecting multiple owners" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id, @m1.id, @m2.id, @m3.id ] }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @m1.id, @m2.id, @m3.id ] }
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.end_date <=> @end_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
@@ -69,7 +69,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "renders new" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id ] }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id ] }
             expect(response).to render_template("maintenance_announcements/new")
         end
     end
@@ -82,7 +82,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id, @vm0.id ], ignore_vms: true }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @vm0.id ], ignore_vms: true}
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.end_date <=> @end_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
@@ -113,7 +113,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "renders new" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id ] }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id ] }
             expect(response).to render_template("maintenance_announcements/new")
         end
     end
@@ -139,7 +139,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id ], ignore_deadlines: true }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id ], ignore_deadlines: true }
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
             expect(MaintenanceAnnouncement.last.impact).to eq("impact")
@@ -169,7 +169,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id ] }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id ] }
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
             expect(MaintenanceAnnouncement.last.impact).to eq("impact")
@@ -186,7 +186,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "renders new" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id, @m1.id ] }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @m1.id ] }
             expect(response).to render_template("maintenance_announcements/new")
         end
     end
@@ -198,7 +198,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", template_id: @template.id, machine_ids: [ @m0.id, @m1.id ] }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @m1.id ] }
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.end_date <=> @end_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")

--- a/spec/factories/maintenance_announcements.rb
+++ b/spec/factories/maintenance_announcements.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :maintenance_announcement do
-    date "2018-02-26 15:52:54"
+    begin_date "2018-02-26 15:52:54"
+    end_date "2018-02-27 15:52:54"
     reason "MyText"
     impact "MyText"
     maintenance_template nil

--- a/spec/models/maintenance_ticket_spec.rb
+++ b/spec/models/maintenance_ticket_spec.rb
@@ -1,5 +1,121 @@
 require 'spec_helper'
 
 RSpec.describe MaintenanceTicket, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before(:each) do
+    @current_user = FactoryGirl.create :user
+    allow(User).to receive(:current).and_return(@current_user)
+
+    @owner0 = FactoryGirl.create(:owner, users: [@current_user], announcement_contact: "owner0@example.org")
+
+    @m0 = FactoryGirl.create(:machine, owner: @owner0, announcement_deadline: 0)
+    @m1 = FactoryGirl.create(:machine, owner: @owner0, announcement_deadline: 0)
+
+    x = Time.now
+    @begin_date = Time.zone.local(x.year,x.month,x.day,x.hour,x.min,0)
+    @end_date = @begin_date + 1.days
+    @template = FactoryGirl.create(:maintenance_template)
+    @template.body = %q#%{begin_date} %{end_date} %{begin_time} %{end_time} %{begin_full} %{end_full} %{reason} %{impact} %{machines} %{user}#
+    @template.subject = @template.body
+    @announcement = FactoryGirl.create(:maintenance_announcement, maintenance_template: @template, user: @current_user, begin_date: @begin_date, end_date: @end_date, email: nil)
+    @announcement_with_mail = FactoryGirl.create(:maintenance_announcement, maintenance_template: @template, user: @current_user, begin_date: @begin_date, end_date: @end_date, email: "mail@example.com")
+  end
+
+  describe "format_body" do
+    describe "without announcement email" do
+      it "formats the contents of a ticket, including machines" do
+        x = FactoryGirl.create(:maintenance_ticket, maintenance_announcement: @announcement, machines: [@m0, @m1])
+        p = { 
+          begin_date: @announcement.begin_date.to_formatted_s(:announcement_date),
+          end_date: @announcement.end_date.to_formatted_s(:announcement_date),
+          begin_time: @announcement.begin_date.to_formatted_s(:announcement_time),
+          end_time: @announcement.end_date.to_formatted_s(:announcement_time),
+          begin_full: @announcement.begin_date.to_formatted_s(:announcement_full),
+          end_full: @announcement.end_date.to_formatted_s(:announcement_full),
+          reason: @announcement.reason,
+          impact: @announcement.impact,
+          machines: x.format_machines_fqdns,
+          user: @announcement.user.display_name 
+        }
+
+        expect(x.format_body).to eq(%q#%{begin_date} %{end_date} %{begin_time} %{end_time} %{begin_full} %{end_full} %{reason} %{impact} %{machines} %{user}# % p)
+      end
+    end
+
+    describe "with announcement email" do
+      it "formats the contents of a ticket, without machines" do
+        x = FactoryGirl.create(:maintenance_ticket, maintenance_announcement: @announcement_with_mail, machines: [@m0, @m1])
+        p = { 
+          begin_date: @announcement_with_mail.begin_date.to_formatted_s(:announcement_date),
+          end_date: @announcement_with_mail.end_date.to_formatted_s(:announcement_date),
+          begin_time: @announcement_with_mail.begin_date.to_formatted_s(:announcement_time),
+          end_time: @announcement_with_mail.end_date.to_formatted_s(:announcement_time),
+          begin_full: @announcement_with_mail.begin_date.to_formatted_s(:announcement_full),
+          end_full: @announcement_with_mail.end_date.to_formatted_s(:announcement_full),
+          reason: @announcement_with_mail.reason,
+          impact: @announcement_with_mail.impact,
+          machines: "",
+          user: @announcement_with_mail.user.display_name 
+        }
+
+        expect(x.format_body).to eq(%q#%{begin_date} %{end_date} %{begin_time} %{end_time} %{begin_full} %{end_full} %{reason} %{impact} %{machines} %{user}# % p)
+      end
+    end
+  end
+
+  describe "format_subject" do
+    describe "without announcement email" do
+      it "formats the subject of a ticket, with machines" do
+        x = FactoryGirl.create(:maintenance_ticket, maintenance_announcement: @announcement, machines: [@m0, @m1])
+        p = { 
+          begin_date: @announcement.begin_date.to_formatted_s(:announcement_date),
+          end_date: @announcement.end_date.to_formatted_s(:announcement_date),
+          begin_time: @announcement.begin_date.to_formatted_s(:announcement_time),
+          end_time: @announcement.end_date.to_formatted_s(:announcement_time),
+          begin_full: @announcement.begin_date.to_formatted_s(:announcement_full),
+          end_full: @announcement.end_date.to_formatted_s(:announcement_full),
+          reason: @announcement.reason,
+          impact: @announcement.impact,
+          machines: x.format_machines_fqdns,
+          user: @announcement.user.display_name 
+        }
+        expect(x.format_subject).to eq(%q#%{begin_date} %{end_date} %{begin_time} %{end_time} %{begin_full} %{end_full} %{reason} %{impact} %{machines} %{user}# % p)
+      end
+    end
+
+    describe "with announcement email" do
+      it "formats the subject of a ticket, without machines" do
+        x = FactoryGirl.create(:maintenance_ticket, maintenance_announcement: @announcement_with_mail, machines: [@m0, @m1])
+        p = { 
+          begin_date: @announcement_with_mail.begin_date.to_formatted_s(:announcement_date),
+          end_date: @announcement_with_mail.end_date.to_formatted_s(:announcement_date),
+          begin_time: @announcement_with_mail.begin_date.to_formatted_s(:announcement_time),
+          end_time: @announcement_with_mail.end_date.to_formatted_s(:announcement_time),
+          begin_full: @announcement_with_mail.begin_date.to_formatted_s(:announcement_full),
+          end_full: @announcement_with_mail.end_date.to_formatted_s(:announcement_full),
+          reason: @announcement_with_mail.reason,
+          impact: @announcement_with_mail.impact,
+          machines: "",
+          user: @announcement_with_mail.user.display_name 
+        }
+        expect(x.format_subject).to eq(%q#%{begin_date} %{end_date} %{begin_time} %{end_time} %{begin_full} %{end_full} %{reason} %{impact} %{machines} %{user}# % p)
+        end
+      end
+    end
+
+  describe "email" do
+    describe "without announcement email" do
+      it "returns the email address for the owner" do
+        x = FactoryGirl.create(:maintenance_ticket, maintenance_announcement: @announcement, machines: [@m0, @m1])
+
+        expect(x.email).to eq(@owner0.announcement_contact)
+      end
+    end
+
+    describe "with announcement email" do
+      it "returns the email address of the announcement" do
+        x = FactoryGirl.create(:maintenance_ticket, maintenance_announcement: @announcement_with_mail, machines: [@m0, @m1])
+        expect(x.email).to eq(@announcement_with_mail.email)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When creating an announcement, a specific mail address can now be set to where the announcement is sent (e.g. to send to a mailing list).