### PR TITLE
Announcement mail

### DIFF
--- a/app/controllers/maintenance_announcements_controller.rb
+++ b/app/controllers/maintenance_announcements_controller.rb
@@ -75,7 +75,7 @@ class MaintenanceAnnouncementsController < ApplicationController
         # get all machines where the deadline is exceeded
         @exceeded_deadlines = check_deadlines(@selected_machines, @begin_date)
 
-        if (not @no_deadline.empty?) or (not @no_contacts.empty?) or (not @missing_vms.empty? and not params[:ignore_vms] == "true") or (not @exceeded_deadlines.empty? and not params[:ignore_deadlines] == "true") or (@no_maintenance_template)
+        if (not @no_deadline.empty? and not params[:ignore_deadlines] == "true") or (not @no_contacts.empty? and not @email) or (not @missing_vms.empty? and not params[:ignore_vms] == "true") or (not @exceeded_deadlines.empty? and not params[:ignore_deadlines] == "true") or (@no_maintenance_template)
             return render :new
         end
 

--- a/app/controllers/maintenance_announcements_controller.rb
+++ b/app/controllers/maintenance_announcements_controller.rb
@@ -75,7 +75,11 @@ class MaintenanceAnnouncementsController < ApplicationController
         # get all machines where the deadline is exceeded
         @exceeded_deadlines = check_deadlines(@selected_machines, @begin_date)
 
-        if (not @no_deadline.empty? and not params[:ignore_deadlines] == "true") or (not @no_contacts.empty? and not @email) or (not @missing_vms.empty? and not params[:ignore_vms] == "true") or (not @exceeded_deadlines.empty? and not params[:ignore_deadlines] == "true") or (@no_maintenance_template)
+        if  (not (@no_deadline.empty? or params[:ignore_deadlines] == "1")) or
+            (not (@no_contacts.empty? or @email)) or
+            (not (@missing_vms.empty? or params[:ignore_vms] == "1")) or
+            (not (@exceeded_deadlines.empty? or params[:ignore_deadlines] == "1")) or
+            (@no_maintenance_template)
             return render :new
         end
 

--- a/app/controllers/maintenance_announcements_controller.rb
+++ b/app/controllers/maintenance_announcements_controller.rb
@@ -18,7 +18,7 @@ class MaintenanceAnnouncementsController < ApplicationController
         @no_contacts = Array.new
         @missing_vms = Array.new
         @begin_date = Time.zone.now
-        @end_date = Time.zone.now
+        @end_date = Time.zone.now + 1.hours
         @exceeded_deadlines = Array.new
 
         # selected machines if we got back here from create. map them with to_i so we can use them as integers in the template.

--- a/app/views/maintenance_announcements/new.html.erb
+++ b/app/views/maintenance_announcements/new.html.erb
@@ -84,13 +84,12 @@ have a wizard style dialog done on the client side #%>
         <div class="span6">
           <%= label_tag(:email, "E-Mail Address") %>
           <%= autocomplete_field_tag(:email, '', autocomplete_maintenance_announcement_email_maintenance_announcements_path) %>
-          <%#= email_field_tag(:email, :url => "foobar", :as => :autocomplete) #%>
 
           <%= label_tag(:begin_date, "Begin") %>
-          <%= datetime_select(:maintenance_announcement, :begin_date, default: {minute: 0 } ) %>
+          <%= datetime_select(:maintenance_announcement, :begin_date, default: { year: @begin_date.year, month: @begin_date.month, day: @begin_date.day, hour: @begin_date.hour, minute: 0} ) %>
 
           <%= label_tag(:begin_date, "End") %>
-          <%= datetime_select(:maintenance_announcement, :end_date, default: {minute: 0 } ) %>
+          <%= datetime_select(:maintenance_announcement, :end_date, default: { year: @end_date.year, month: @end_date.month, day: @end_date.day, hour: @end_date.hour, minute: 0} ) %>
 
           <%= label_tag("","") %>
           <%= submit_tag("Send Announcement") %>

--- a/spec/controllers/maintenance_announcements_controller_spec.rb
+++ b/spec/controllers/maintenance_announcements_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @vm0.id ], ignore_vms: true}
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id, @vm0.id ], ignore_vms: "1"}
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.end_date <=> @end_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
@@ -139,7 +139,7 @@ RSpec.describe MaintenanceAnnouncementsController, type: :controller do
         end
     
         it "creates a new maintenance announcement" do
-            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id ], ignore_deadlines: true }
+            post :create, params: {maintenance_announcement: @date_params, reason: "reason", impact: "impact", maintenance_template_id: @template.id, machine_ids: [ @m0.id ], ignore_deadlines: "1" }
             expect(MaintenanceAnnouncement.last.begin_date <=> @begin_date).to eq(0)
             expect(MaintenanceAnnouncement.last.reason).to eq("reason")
             expect(MaintenanceAnnouncement.last.impact).to eq("impact")


### PR DESCRIPTION
better handling of empty contacts and empty deadlines:
- if using a single mail address, ignore empty contacts of owners.
- if ignoring deadlines, also ignore unset deadlines.

de morgans rules to make the failure condition clearer, fix checkboxes

better default dates:
- add 1 hour as default for end time