### PR TITLE
Placeholder validation

### DIFF
--- a/app/controllers/maintenance_templates_controller.rb
+++ b/app/controllers/maintenance_templates_controller.rb
@@ -12,9 +12,9 @@ class MaintenanceTemplatesController < ApplicationController
     end
 
     def create
-        maintenance_template = MaintenanceTemplate.new(maintenance_template_params)
-        if maintenance_template.save
-            return redirect_to maintenance_template_path(maintenance_template)
+        @maintenance_template = MaintenanceTemplate.new(maintenance_template_params)
+        if @maintenance_template.save
+            return redirect_to maintenance_template_path(@maintenance_template)
         end
 
         return render :new

--- a/app/models/maintenance_template.rb
+++ b/app/models/maintenance_template.rb
@@ -1,11 +1,51 @@
 class MaintenanceTemplate < ApplicationRecord
     has_many :maintenance_announcements
 
+    validate :validate_placeholders
+
+    # this hash defines the valid placeholders, and the way the raw values are formatted
+    @@valid_placeholders = {
+        begin_date: proc {|x| x.maintenance_announcement.begin_date.to_formatted_s(:announcement_date)},
+        end_date: proc {|x| x.maintenance_announcement.end_date.to_formatted_s(:announcement_date)},
+        begin_time: proc {|x| x.maintenance_announcement.begin_date.to_formatted_s(:announcement_time)},
+        end_time: proc {|x| x.maintenance_announcement.end_date.to_formatted_s(:announcement_time)},
+        begin_full: proc {|x| x.maintenance_announcement.begin_date.to_formatted_s(:announcement_full)},
+        end_full: proc {|x| x.maintenance_announcement.end_date.to_formatted_s(:announcement_full)},
+        reason: proc {|x| x.maintenance_announcement.reason },
+        impact: proc {|x| x.maintenance_announcement.impact },
+        machines: proc {|x| x.maintenance_announcement.email ? "" : x.machines.pluck(:fqdn).join(" ") },
+        user: proc {|x| x.maintenance_announcement.user.display_name }
+    }
+
     def format_subject(params)
         subject % params
     end
 
     def format_body(params)
         body % params
+    end
+
+    def format_params(ticket)
+        out = {}
+
+        @@valid_placeholders.each do |k,v|
+            out[k] = v.call(ticket)
+        end
+
+        out
+    end
+
+    def validate_placeholders
+        begin
+            subject % @@valid_placeholders
+        rescue
+            errors.add(:subject, "subject contains invalid placeholder")
+        end
+
+        begin
+            body % @@valid_placeholders
+        rescue
+            errors.add(:body, "subject contains invalid placeholder")
+        end
     end
 end

--- a/app/models/maintenance_ticket.rb
+++ b/app/models/maintenance_ticket.rb
@@ -6,18 +6,18 @@ class MaintenanceTicket < ApplicationRecord
   def format_body
     a = maintenance_announcement
     t = a.maintenance_template
-    t.format_body(format_params)
+    t.format_body(t.format_params(self))
   end
 
   def format_subject
     a = maintenance_announcement
     t = a.maintenance_template
-    t.format_subject(format_params)
+    t.format_subject(t.format_params(self))
   end
 
-  def format_machines_fqdns
-    machines.pluck(:fqdn).join(", ")
-  end
+  # def format_machines_fqdns
+  #   machines.pluck(:fqdn).join(", ")
+  # end
 
   # we only have one owner
   def owner
@@ -35,27 +35,4 @@ class MaintenanceTicket < ApplicationRecord
 
   private
 
-  def format_params
-    a = maintenance_announcement
-    t = a.maintenance_template
-    p = { 
-      begin_date: a.begin_date.to_formatted_s(:announcement_date),
-      end_date: a.end_date.to_formatted_s(:announcement_date),
-      begin_time: a.begin_date.to_formatted_s(:announcement_time),
-      end_time: a.end_date.to_formatted_s(:announcement_time),
-      begin_full: a.begin_date.to_formatted_s(:announcement_full),
-      end_full: a.end_date.to_formatted_s(:announcement_full),
-      reason: a.reason,
-      impact: a.impact,
-      machines: format_machines_fqdns,
-      user: a.user.display_name 
-    }
-
-    # don't show machines in formatted ticket if we send to one address
-    if maintenance_announcement.email
-      p[:machines] = ""
-    end
-    
-    p
-  end
 end

--- a/spec/models/maintenance_ticket_spec.rb
+++ b/spec/models/maintenance_ticket_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe MaintenanceTicket, type: :model do
           end_full: @announcement.end_date.to_formatted_s(:announcement_full),
           reason: @announcement.reason,
           impact: @announcement.impact,
-          machines: x.format_machines_fqdns,
+          machines: @announcement.email ? "" : x.machines.pluck(:fqdn).join(" "),
           user: @announcement.user.display_name 
         }
 
@@ -75,7 +75,7 @@ RSpec.describe MaintenanceTicket, type: :model do
           end_full: @announcement.end_date.to_formatted_s(:announcement_full),
           reason: @announcement.reason,
           impact: @announcement.impact,
-          machines: x.format_machines_fqdns,
+          machines: @announcement.email ? "" : x.machines.pluck(:fqdn).join(" "),
           user: @announcement.user.display_name 
         }
         expect(x.format_subject).to eq(%q#%{begin_date} %{end_date} %{begin_time} %{end_time} %{begin_full} %{end_full} %{reason} %{impact} %{machines} %{user}# % p)


### PR DESCRIPTION
this adds a validation to maintenance templates, checking if only the
allowed placeholders are used. additionally, the formatting of the
values used is moved from the ticket to the template.