### PR TITLE
replace os and os release initialization with autocomplete

### DIFF
--- a/app/controllers/machines_controller.rb
+++ b/app/controllers/machines_controller.rb
@@ -139,6 +139,14 @@ class MachinesController < ApplicationController
     autocomplete_general("business_notification", params[:term])
   end
 
+  def autocomplete_os
+    autocomplete_general("os", params[:term])
+  end
+
+  def autocomplete_os_release
+    autocomplete_general("os_release", params[:term])
+  end
+
   private
 
   def machine_params

--- a/app/forms/editable_machine_form.rb
+++ b/app/forms/editable_machine_form.rb
@@ -153,13 +153,13 @@ class EditableMachineForm
 
   def os_list
     (
-      Machine.select(:os).distinct.map(&:os).compact + os_other
+      Machine.select(:os).distinct.map(&:os).compact
     ).uniq.sort
   end
 
   def os_release_list
     (
-      Machine.select(:os_release).distinct.map(&:os_release).compact + os_release_other
+      Machine.select(:os_release).distinct.map(&:os_release).compact
     ).uniq.sort
   end
 
@@ -176,14 +176,6 @@ class EditableMachineForm
   end
 
   private
-
-  def os_other
-    IDB.config.machine_details.os
-  end
-
-  def os_release_other
-    IDB.config.machine_details.os_release
-  end
 
   def recursive_symbolize_keys(my_hash)
     case my_hash

--- a/app/views/machines/_details_form.html.erb
+++ b/app/views/machines/_details_form.html.erb
@@ -23,10 +23,13 @@
         collection: @machine_details.core_collection,
         default: @machine_details.core_collection.first %>
 
-      <%= f.input :os, disabled: @machine_details.field_disabled?("os"),
-        collection: @machine_details.os_list %>
-      <%= f.input :os_release, disabled: @machine_details.field_disabled?("os_release"),
-        collection: @machine_details.os_release_list %>
+      <%= f.input :os, :url => autocomplete_os_machines_path,
+        as: :autocomplete, input_html: {rows: 8}, label: "Operating System",
+        disabled: @machine_details.field_disabled?("os") %>
+      <%= f.input :os_release, :url => autocomplete_os_release_machines_path,
+        as: :autocomplete, input_html: {rows: 8}, label: "Operating System Release",
+        disabled: @machine_details.field_disabled?("os_release") %>
+      
       <%= f.input :serialnumber, disabled: @machine_details.field_disabled?("serialnumber") %>
 
       <%= f.input :device_type_name, disabled: @machine_details.field_disabled?("device_type_name"),

--- a/config-example/application.yml
+++ b/config-example/application.yml
@@ -96,49 +96,6 @@ defaults: &defaults
       is_virtual: true
     - id: 3
       name: 'switch'
-  machine_details:
-    # http://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
-    os:
-      - 'Windows'
-      - 'Windows Server'
-      - 'SLES'
-      - 'RHEL'
-      - 'pfSense'
-      - 'UCS'
-    os_release:
-      - '1.2.1'
-      - '1.2.2'
-      - '1.2.3'
-      - '2.0'
-      - '2.0.1'
-      - '2.0.1'
-      - '2.0.2'
-      - '2.0.3'
-      - '2.1'
-      - '2.2'
-      - '2.3'
-      - '2.3.3'
-      - '3.0'
-      - '3.1'
-      - '3.2'
-      - '3.3'
-      - '4.0'
-      - '4.1'
-      - '5'
-      - '6'
-      - '7'
-      - '8'
-      - '10'
-      - 'Vista'
-      - '2012 R2'
-      - '2012'
-      - '2008 R2'
-      - '2008'
-      - '10 SP 2'
-      - '10 SP 3'
-      - '10 SP 4'
-      - '11 SP 1'
-      - '11 SP 2'
 
 development:
   <<: *defaults

--- a/config-example/routes.rb
+++ b/config-example/routes.rb
@@ -15,6 +15,8 @@ InfrastructureDb::Application.routes.draw do
     get :autocomplete_business_purpose, :on => :collection
     get :autocomplete_business_criticality, :on => :collection
     get :autocomplete_business_notification, :on => :collection
+    get :autocomplete_os, :on => :collection
+    get :autocomplete_os_release, :on => :collection
     member do
       get 'maintenance_record/new', to: 'maintenance_records#new'
     end
@@ -32,7 +34,6 @@ InfrastructureDb::Application.routes.draw do
   resources :untracked_machines, only: [:index, :destroy], :constraints => { :id => /[^\/]+/ }
   resources :deleted_machines, only: [:index, :edit, :destroy]
   resources :deleted_owners, only: [:index, :edit, :destroy]
-  resources :deleted_users, only: [:index, :edit, :destroy]
   resources :outdated_machines, only: [:index]
   resources :lexware_imports, only: [:new, :create]
   resources :inventory_imports, only: [:new, :create]
@@ -51,7 +52,8 @@ InfrastructureDb::Application.routes.draw do
   resources :api_tokens
   resources :softwares, only: [:index]
   resources :cloud_providers
-  resources :users, only: [:index, :show, :update, :destroy]
+  resources :users, only: [:index, :edit, :update]
+
   resources :maintenance_announcements do
     get :autocomplete_maintenance_announcement_email, :on => :collection
   end

--- a/spec/forms/editable_machine_form_spec.rb
+++ b/spec/forms/editable_machine_form_spec.rb
@@ -266,15 +266,20 @@ describe EditableMachineForm do
   describe '#os_list' do
     it 'returns a list of operating systems' do
       form.update(attributes)
-      m = FactoryGirl.create(:machine, os: "Windows") # create a duplicate Windows entry
-      expect(form.os_list).to eq(["RHEL", "SLES", "UCS", "Ubuntu", "Windows", "Windows Server", "pfSense"])
+      m = FactoryGirl.create(:machine, os: "Windows")
+      m = FactoryGirl.create(:machine, os: "FreeBSD")
+      expect(form.os_list).to eq(["FreeBSD","Ubuntu", "Windows"])
     end
   end
 
   describe '#os_release_list' do
     it 'returns a list of operating releases' do
       form.update(attributes)
-      m = FactoryGirl.create(:machine, os_release: "7") # create a duplicate "7" entry
+      m = FactoryGirl.create(:machine, os_release: "1")
+      m = FactoryGirl.create(:machine, os_release: "2")
+      m = FactoryGirl.create(:machine, os_release: "3")
+      m = FactoryGirl.create(:machine, os_release: "3")
+      expect(form.os_release_list).to eq(["1",attributes[:os_release],"2","3"])
       expect(form.os_release_list.length).to eq(form.os_release_list.uniq.length)
     end
   end


### PR DESCRIPTION
remove the initialization of os and os release from values of
application.yml and replace it with autocomplete from existing
machines. machines tend to be managed automatically, so we get a
good list of values for free while also keeping the possibility of
adding custom values