### PR TITLE
don't use link_to in user method of presenter

### DIFF
--- a/app/presenters/version_presenter.rb
+++ b/app/presenters/version_presenter.rb
@@ -24,7 +24,7 @@ class VersionPresenter < Keynote::Presenter
       return u.display_name if u
     else
       t = ApiToken.find_by_token(version.whodunnit)
-      return link_to(t.name, t) if t
+      return t.name if t
     end
     return '?'
   end


### PR DESCRIPTION
while link_to is available in views from ActiveView::Helpers, it isn't loaded when the presenter is used from a mailer.