### PR TITLE
fixed create machine through API with softdelete false

### DIFF
--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -196,8 +196,10 @@ class Machine < ActiveRecord::Base
   end
 
   def validate_fqdn_not_in_deleted
-    if Machine.only_deleted.find_by_fqdn(fqdn)
-      errors.add(:fqdn, "FQDN in use by deleted machine.")
+    if IDB.config.modules.softdelete
+      if Machine.only_deleted.find_by_fqdn(fqdn)
+        errors.add(:fqdn, "FQDN in use by deleted machine.")
+      end
     end
   end
 


### PR DESCRIPTION
With `softdelete: false` in `application.yml` it was not possible to create a new machine via APIv3:
```
I, [2021-04-29T11:49:12.729203 #213]  INFO -- : Started POST "/api/v3/machines" for 172.18.0.1 at 2021-04-29 11:49:12 +0200
F, [2021-04-29T11:49:12.807063 #213] FATAL -- :   
F, [2021-04-29T11:49:12.824126 #213] FATAL -- : NoMethodError (undefined method `only_deleted' for #<Class:0x000055d1b2fba228>):
F, [2021-04-29T11:49:12.824159 #213] FATAL -- :   
F, [2021-04-29T11:49:12.824181 #213] FATAL -- : app/models/machine.rb:199:in `validate_fqdn_not_in_deleted'
app/api/v3/machines.rb:369:in `block (2 levels) in <class:Machines>'
```