### PR TITLE
fixed mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN tar xf v${ruby_build_version}
 RUN ruby-build-${ruby_build_version}/install.sh
 
 # install ruby dependencies
-RUN apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev libdb-dev bzip2
+RUN apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev libdb-dev bzip2 shared-mime-info
 
 # install ruby, skipping docs
 RUN env RUBY_CONFIGURE_OPTS=--disable-install-doc ruby-build ${ruby_version} /usr/local


### PR DESCRIPTION
Apparently the gem `mimemagic-0.3.5` was pulled from the repository and is no loger available.
This patch replaces it with `mimemagic-0.3.10` which seems to fix the problem while executing `bundle install`.
It also adds the dependency `shared-mime-info` to `Dockerfile`.